### PR TITLE
AddLetterView UI 및 텍스트 인식 기능 구현

### DIFF
--- a/PJ3T3_Postie.xcodeproj/project.pbxproj
+++ b/PJ3T3_Postie.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		9E9F6ADF2B5765DE003DFE83 /* Color.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E9F6ADE2B5765DD003DFE83 /* Color.swift */; };
 		CE7E50782B579D6800955F31 /* AddLetterViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE7E50772B579D6800955F31 /* AddLetterViewModel.swift */; };
 		CEF09E452B57B6C500BE67E4 /* UIImagePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEF09E442B57B6C500BE67E4 /* UIImagePicker.swift */; };
+		CEF09E472B57BD8500BE67E4 /* LetterImageFullScreenView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEF09E462B57BD8500BE67E4 /* LetterImageFullScreenView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -69,6 +70,7 @@
 		9E9F6ADE2B5765DD003DFE83 /* Color.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Color.swift; sourceTree = "<group>"; };
 		CE7E50772B579D6800955F31 /* AddLetterViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddLetterViewModel.swift; sourceTree = "<group>"; };
 		CEF09E442B57B6C500BE67E4 /* UIImagePicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIImagePicker.swift; sourceTree = "<group>"; };
+		CEF09E462B57BD8500BE67E4 /* LetterImageFullScreenView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LetterImageFullScreenView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -220,6 +222,7 @@
 				9E9F6AD32B576411003DFE83 /* LetterDetailView.swift */,
 				9E9F6AD52B576423003DFE83 /* AddLetterView.swift */,
 				CEF09E442B57B6C500BE67E4 /* UIImagePicker.swift */,
+				CEF09E462B57BD8500BE67E4 /* LetterImageFullScreenView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -393,6 +396,7 @@
 				9E9F6AD82B57642D003DFE83 /* FirestoreViewModel.swift in Sources */,
 				9E9F6AD62B576423003DFE83 /* AddLetterView.swift in Sources */,
 				9E9F6ACE2B5763CA003DFE83 /* AuthViewModel.swift in Sources */,
+				CEF09E472B57BD8500BE67E4 /* LetterImageFullScreenView.swift in Sources */,
 				9E9F6AC42B57639D003DFE83 /* ShopViewModel.swift in Sources */,
 				CEF09E452B57B6C500BE67E4 /* UIImagePicker.swift in Sources */,
 				9E9F6AC22B576393003DFE83 /* MapApi.swift in Sources */,

--- a/PJ3T3_Postie.xcodeproj/project.pbxproj
+++ b/PJ3T3_Postie.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		9E9F6ADC2B57643F003DFE83 /* Letter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E9F6ADB2B57643F003DFE83 /* Letter.swift */; };
 		9E9F6ADF2B5765DE003DFE83 /* Color.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E9F6ADE2B5765DD003DFE83 /* Color.swift */; };
 		CE7E50782B579D6800955F31 /* AddLetterViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE7E50772B579D6800955F31 /* AddLetterViewModel.swift */; };
+		CEF09E452B57B6C500BE67E4 /* UIImagePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEF09E442B57B6C500BE67E4 /* UIImagePicker.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -67,6 +68,7 @@
 		9E9F6ADB2B57643F003DFE83 /* Letter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Letter.swift; sourceTree = "<group>"; };
 		9E9F6ADE2B5765DD003DFE83 /* Color.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Color.swift; sourceTree = "<group>"; };
 		CE7E50772B579D6800955F31 /* AddLetterViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddLetterViewModel.swift; sourceTree = "<group>"; };
+		CEF09E442B57B6C500BE67E4 /* UIImagePicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIImagePicker.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -217,6 +219,7 @@
 				9E9F6AB52B5762E5003DFE83 /* HomeView.swift */,
 				9E9F6AD32B576411003DFE83 /* LetterDetailView.swift */,
 				9E9F6AD52B576423003DFE83 /* AddLetterView.swift */,
+				CEF09E442B57B6C500BE67E4 /* UIImagePicker.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -391,6 +394,7 @@
 				9E9F6AD62B576423003DFE83 /* AddLetterView.swift in Sources */,
 				9E9F6ACE2B5763CA003DFE83 /* AuthViewModel.swift in Sources */,
 				9E9F6AC42B57639D003DFE83 /* ShopViewModel.swift in Sources */,
+				CEF09E452B57B6C500BE67E4 /* UIImagePicker.swift in Sources */,
 				9E9F6AC22B576393003DFE83 /* MapApi.swift in Sources */,
 				9E9F6AD42B576411003DFE83 /* LetterDetailView.swift in Sources */,
 				9E9F6ABE2B576358003DFE83 /* MapViewModel.swift in Sources */,
@@ -536,10 +540,11 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"PJ3T3_Postie/Preview Content\"";
-				DEVELOPMENT_TEAM = Y6QXM3Q994;
+				DEVELOPMENT_TEAM = C9D4D98Z8R;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = Postie;
+				INFOPLIST_KEY_NSCameraUsageDescription = "편지 사진을 가져오기 위해 카메라 권한이 필요합니다.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -567,10 +572,11 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"PJ3T3_Postie/Preview Content\"";
-				DEVELOPMENT_TEAM = Y6QXM3Q994;
+				DEVELOPMENT_TEAM = C9D4D98Z8R;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = Postie;
+				INFOPLIST_KEY_NSCameraUsageDescription = "편지 사진을 가져오기 위해 카메라 권한이 필요합니다.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;

--- a/PJ3T3_Postie.xcodeproj/project.pbxproj
+++ b/PJ3T3_Postie.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		9E9F6ADA2B576438003DFE83 /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E9F6AD92B576438003DFE83 /* User.swift */; };
 		9E9F6ADC2B57643F003DFE83 /* Letter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E9F6ADB2B57643F003DFE83 /* Letter.swift */; };
 		9E9F6ADF2B5765DE003DFE83 /* Color.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E9F6ADE2B5765DD003DFE83 /* Color.swift */; };
+		CE7E50782B579D6800955F31 /* AddLetterViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE7E50772B579D6800955F31 /* AddLetterViewModel.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -65,6 +66,7 @@
 		9E9F6AD92B576438003DFE83 /* User.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
 		9E9F6ADB2B57643F003DFE83 /* Letter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Letter.swift; sourceTree = "<group>"; };
 		9E9F6ADE2B5765DD003DFE83 /* Color.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Color.swift; sourceTree = "<group>"; };
+		CE7E50772B579D6800955F31 /* AddLetterViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddLetterViewModel.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -204,6 +206,7 @@
 			children = (
 				9E9F6AB72B5762EF003DFE83 /* HomeViewModel.swift */,
 				9E9F6AD72B57642D003DFE83 /* FirestoreViewModel.swift */,
+				CE7E50772B579D6800955F31 /* AddLetterViewModel.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -376,6 +379,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CE7E50782B579D6800955F31 /* AddLetterViewModel.swift in Sources */,
 				9E9F6AB62B5762E5003DFE83 /* HomeView.swift in Sources */,
 				9E0FA11E2B54D27A001CEEB9 /* ContentView.swift in Sources */,
 				9E9F6ADF2B5765DE003DFE83 /* Color.swift in Sources */,

--- a/PJ3T3_Postie.xcodeproj/project.pbxproj
+++ b/PJ3T3_Postie.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		CE7E50782B579D6800955F31 /* AddLetterViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE7E50772B579D6800955F31 /* AddLetterViewModel.swift */; };
 		CEF09E452B57B6C500BE67E4 /* UIImagePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEF09E442B57B6C500BE67E4 /* UIImagePicker.swift */; };
 		CEF09E472B57BD8500BE67E4 /* LetterImageFullScreenView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEF09E462B57BD8500BE67E4 /* LetterImageFullScreenView.swift */; };
+		CEF09E492B57BFBF00BE67E4 /* TextRecognizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEF09E482B57BFBF00BE67E4 /* TextRecognizer.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -71,6 +72,7 @@
 		CE7E50772B579D6800955F31 /* AddLetterViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddLetterViewModel.swift; sourceTree = "<group>"; };
 		CEF09E442B57B6C500BE67E4 /* UIImagePicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIImagePicker.swift; sourceTree = "<group>"; };
 		CEF09E462B57BD8500BE67E4 /* LetterImageFullScreenView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LetterImageFullScreenView.swift; sourceTree = "<group>"; };
+		CEF09E482B57BFBF00BE67E4 /* TextRecognizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextRecognizer.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -211,6 +213,7 @@
 				9E9F6AB72B5762EF003DFE83 /* HomeViewModel.swift */,
 				9E9F6AD72B57642D003DFE83 /* FirestoreViewModel.swift */,
 				CE7E50772B579D6800955F31 /* AddLetterViewModel.swift */,
+				CEF09E482B57BFBF00BE67E4 /* TextRecognizer.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -401,6 +404,7 @@
 				CEF09E452B57B6C500BE67E4 /* UIImagePicker.swift in Sources */,
 				9E9F6AC22B576393003DFE83 /* MapApi.swift in Sources */,
 				9E9F6AD42B576411003DFE83 /* LetterDetailView.swift in Sources */,
+				CEF09E492B57BFBF00BE67E4 /* TextRecognizer.swift in Sources */,
 				9E9F6ABE2B576358003DFE83 /* MapViewModel.swift in Sources */,
 				9E9F6AC82B5763AD003DFE83 /* SettingViewModel.swift in Sources */,
 				9E9F6AD22B5763F3003DFE83 /* SettingsRowView.swift in Sources */,

--- a/PJ3T3_Postie/Core/Home/View/AddLetterView.swift
+++ b/PJ3T3_Postie/Core/Home/View/AddLetterView.swift
@@ -68,13 +68,11 @@ struct AddLetterView: View {
             .confirmationDialog("편지 사진 가져오기", 
                                 isPresented: $addLetterViewModel.showConfirmationDialog) {
                 Button("카메라") {
-                    addLetterViewModel.imagePickerSourceType = .camera
-                    addLetterViewModel.showUIImagePicker = true
+                    addLetterViewModel.showUIImagePicker(sourceType: .camera)
                 }
 
                 Button("앨범") {
-                    addLetterViewModel.imagePickerSourceType = .photoLibrary
-                    addLetterViewModel.showUIImagePicker = true
+                    addLetterViewModel.showUIImagePicker(sourceType: .photoLibrary)
                 }
 
                 Button("스캐너") {

--- a/PJ3T3_Postie/Core/Home/View/AddLetterView.swift
+++ b/PJ3T3_Postie/Core/Home/View/AddLetterView.swift
@@ -8,84 +8,110 @@
 import SwiftUI
 
 struct AddLetterView: View {
+
+    enum Field: Hashable {
+        case sender
+        case receiver
+        case text
+    }
+
     @StateObject private var addLetterViewModel = AddLetterViewModel()
 
+    @FocusState private var focusField: Field?
+
     var body: some View {
-        ZStack {
-            Color(hex: 0xF5F1E8)
-                .ignoresSafeArea()
+        NavigationStack {
+            ZStack {
+                Color(hex: 0xF5F1E8)
+                    .ignoresSafeArea()
 
-            ScrollView {
-                VStack(alignment: .leading) {
-                    Text("보내는 사람")
+                ScrollView {
+                    VStack(alignment: .leading) {
+                        Text("보내는 사람")
 
-                    TextField("", text: $addLetterViewModel.sender)
-                        .padding()
-                        .background(
-                            RoundedRectangle(cornerRadius: 10)
-                                .stroke(Color(hex: 0x807E79), lineWidth: 1)
-                        )
+                        TextField("", text: $addLetterViewModel.sender)
+                            .padding()
+                            .background(
+                                RoundedRectangle(cornerRadius: 10)
+                                    .stroke(Color(hex: 0x807E79), lineWidth: 1)
+                            )
+                            .focused($focusField, equals: .sender)
 
-                    Text("받는 사람")
+                        Text("받는 사람")
 
-                    TextField("", text: $addLetterViewModel.sender)
-                        .padding()
-                        .background(
-                            RoundedRectangle(cornerRadius: 10)
-                                .stroke(Color(hex: 0x807E79), lineWidth: 1)
-                        )
+                        TextField("", text: $addLetterViewModel.receiver)
+                            .padding()
+                            .background(
+                                RoundedRectangle(cornerRadius: 10)
+                                    .stroke(Color(hex: 0x807E79), lineWidth: 1)
+                            )
+                            .focused($focusField, equals: .receiver)
 
-                    Text("편지 날짜")
+                        Text("편지 날짜")
 
-                    DatePicker("날짜", selection: $addLetterViewModel.date, displayedComponents: .date)
-                        .labelsHidden()
-                        .environment(\.locale, Locale.init(identifier: "ko"))
+                        DatePicker("날짜", selection: $addLetterViewModel.date, displayedComponents: .date)
+                            .labelsHidden()
+                            .environment(\.locale, Locale.init(identifier: "ko"))
 
-                    Text("편지 사진")
+                        Text("편지 사진")
 
-                    ScrollView(.horizontal) {
-                        HStack(spacing: 8) {
-                            Button {
-                                // showConfirmationDialog
-                            } label: {
-                                Image(systemName: "envelope.open.fill")
-                                    .padding()
-                                    .frame(width: 100, height: 100)
-                                    .background(
-                                        Color.gray.opacity(0.2),
-                                        in: RoundedRectangle(cornerRadius: 10, style: .continuous)
-                                    )
+                        ScrollView(.horizontal) {
+                            HStack(spacing: 8) {
+                                Button {
+                                    // showConfirmationDialog
+                                } label: {
+                                    Image(systemName: "envelope.open.fill")
+                                        .padding()
+                                        .frame(width: 100, height: 100)
+                                        .background(
+                                            Color.gray.opacity(0.2),
+                                            in: RoundedRectangle(cornerRadius: 10, style: .continuous)
+                                        )
+                                }
                             }
                         }
+                        .scrollIndicators(.never)
+
+                        Text("편지 내용")
+
+                        TextEditor(text: $addLetterViewModel.text)
+                            .scrollContentBackground(.hidden)
+                            .padding()
+                            .lineSpacing(5)
+                            .frame(maxWidth: .infinity)
+                            .frame(height: 280)
+                            .background(
+                                RoundedRectangle(cornerRadius: 10)
+                                    .stroke(Color(hex: 0x807E79), lineWidth: 1)
+                            )
+                            .focused($focusField, equals: .text)
+                            .toolbar {
+                                ToolbarItemGroup(placement: .keyboard) {
+                                    Spacer()
+                                    Button {
+                                        focusField = nil
+                                    } label: {
+                                        Image(systemName: "keyboard.chevron.compact.down")
+                                    }
+                                }
+                            }
                     }
-                    .scrollIndicators(.never)
-                    
-                    Text("편지 내용")
-                    
-                    TextEditor(text: $addLetterViewModel.text)
-                        .scrollContentBackground(.hidden)
-                        .padding()
-                        .lineSpacing(5)
-                        .frame(maxWidth: .infinity)
-                        .frame(height: 280)
-                        .background(
-                            RoundedRectangle(cornerRadius: 10)
-                                .stroke(Color(hex: 0x807E79), lineWidth: 1)
-                        )
+                    .padding()
                 }
-                .padding()
             }
-        }
-        .navigationTitle("편지 등록")
-        .navigationBarTitleDisplayMode(.inline)
-        .toolbarBackground(Color(hex: 0xF5F1E8), for: .navigationBar)
-        .toolbar {
-            ToolbarItemGroup(placement: .topBarTrailing) {
-                Button {
-                    // 편지 저장하기
-                } label : {
-                    Text("완료")
+            .navigationTitle("편지 등록")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbarBackground(Color(hex: 0xF5F1E8), for: .navigationBar)
+            .toolbar {
+
+                ToolbarItemGroup(placement: .topBarTrailing) {
+                    Button {
+                        // 편지 저장하기
+                    } label : {
+                        Text("완료")
+                    }
                 }
+
             }
         }
     }

--- a/PJ3T3_Postie/Core/Home/View/AddLetterView.swift
+++ b/PJ3T3_Postie/Core/Home/View/AddLetterView.swift
@@ -70,14 +70,30 @@ struct AddLetterView: View {
                                 }
 
                                 ForEach(0..<addLetterViewModel.images.count, id: \.self) { index in
-                                    Button {
-                                        // show letterImageView
-                                    } label: {
-                                        Image(uiImage: addLetterViewModel.images[index])
-                                            .resizable()
-                                            .scaledToFill()
-                                            .frame(width: 100, height: 100)
-                                            .clipShape(RoundedRectangle(cornerRadius: 10))
+                                    ZStack {
+                                        Button {
+                                            // show letterImageView
+                                        } label: {
+                                            Image(uiImage: addLetterViewModel.images[index])
+                                                .resizable()
+                                                .scaledToFill()
+                                                .frame(width: 100, height: 100)
+                                                .clipShape(RoundedRectangle(cornerRadius: 10))
+                                        }
+                                        VStack {
+                                            HStack {
+                                                Spacer()
+                                                Button {
+                                                    withAnimation {
+                                                        addLetterViewModel.removeImage(at: index)
+                                                    }
+                                                } label: {
+                                                    Image(systemName: "x.circle")
+                                                }
+                                                .padding(4)
+                                            }
+                                            Spacer()
+                                        }
                                     }
                                 }
                             }

--- a/PJ3T3_Postie/Core/Home/View/AddLetterView.swift
+++ b/PJ3T3_Postie/Core/Home/View/AddLetterView.swift
@@ -8,6 +8,8 @@
 import SwiftUI
 
 struct AddLetterView: View {
+    @StateObject private var addLetterViewModel = AddLetterViewModel()
+
     var body: some View {
         Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
     }

--- a/PJ3T3_Postie/Core/Home/View/AddLetterView.swift
+++ b/PJ3T3_Postie/Core/Home/View/AddLetterView.swift
@@ -142,7 +142,7 @@ struct AddLetterView: View {
                 LetterImageFullScreenView(images: addLetterViewModel.images)
             }
             .sheet(isPresented: $addLetterViewModel.showUIImagePicker, content: {
-                UIImagePicker(sourceType: addLetterViewModel.imagePickerSourceType, selectedImages: $addLetterViewModel.images)
+                UIImagePicker(sourceType: addLetterViewModel.imagePickerSourceType, selectedImages: $addLetterViewModel.images, text: $addLetterViewModel.text)
             })
             .confirmationDialog("편지 사진 가져오기", isPresented: $addLetterViewModel.showConfirmationDialog) {
                 Button("카메라") {

--- a/PJ3T3_Postie/Core/Home/View/AddLetterView.swift
+++ b/PJ3T3_Postie/Core/Home/View/AddLetterView.swift
@@ -113,16 +113,6 @@ struct AddLetterView: View {
                                     .stroke(Color(hex: 0x807E79), lineWidth: 1)
                             )
                             .focused($focusField, equals: .text)
-                            .toolbar {
-                                ToolbarItemGroup(placement: .keyboard) {
-                                    Spacer()
-                                    Button {
-                                        focusField = nil
-                                    } label: {
-                                        Image(systemName: "keyboard.chevron.compact.down")
-                                    }
-                                }
-                            }
                     }
                     .padding()
                 }
@@ -136,6 +126,15 @@ struct AddLetterView: View {
                         // 편지 저장하기
                     } label : {
                         Text("완료")
+                    }
+                }
+
+                ToolbarItemGroup(placement: .keyboard) {
+                    Spacer()
+                    Button {
+                        focusField = nil
+                    } label: {
+                        Image(systemName: "keyboard.chevron.compact.down")
                     }
                 }
             }

--- a/PJ3T3_Postie/Core/Home/View/AddLetterView.swift
+++ b/PJ3T3_Postie/Core/Home/View/AddLetterView.swift
@@ -68,6 +68,18 @@ struct AddLetterView: View {
                                             in: RoundedRectangle(cornerRadius: 10, style: .continuous)
                                         )
                                 }
+
+                                ForEach(0..<addLetterViewModel.images.count, id: \.self) { index in
+                                    Button {
+                                        // show letterImageView
+                                    } label: {
+                                        Image(uiImage: addLetterViewModel.images[index])
+                                            .resizable()
+                                            .scaledToFill()
+                                            .frame(width: 100, height: 100)
+                                            .clipShape(RoundedRectangle(cornerRadius: 10))
+                                    }
+                                }
                             }
                         }
                         .scrollIndicators(.never)

--- a/PJ3T3_Postie/Core/Home/View/AddLetterView.swift
+++ b/PJ3T3_Postie/Core/Home/View/AddLetterView.swift
@@ -27,92 +27,11 @@ struct AddLetterView: View {
 
                 ScrollView {
                     VStack(alignment: .leading) {
-                        Text("보내는 사람")
+                        letterInfoSection
 
-                        TextField("", text: $addLetterViewModel.sender)
-                            .padding()
-                            .background(
-                                RoundedRectangle(cornerRadius: 10)
-                                    .stroke(Color(hex: 0x807E79), lineWidth: 1)
-                            )
-                            .focused($focusField, equals: .sender)
+                        letterImagesSection
 
-                        Text("받는 사람")
-
-                        TextField("", text: $addLetterViewModel.receiver)
-                            .padding()
-                            .background(
-                                RoundedRectangle(cornerRadius: 10)
-                                    .stroke(Color(hex: 0x807E79), lineWidth: 1)
-                            )
-                            .focused($focusField, equals: .receiver)
-
-                        Text("편지 날짜")
-
-                        DatePicker("날짜", selection: $addLetterViewModel.date, displayedComponents: .date)
-                            .labelsHidden()
-                            .environment(\.locale, Locale.init(identifier: "ko"))
-
-                        Text("편지 사진")
-
-                        ScrollView(.horizontal) {
-                            HStack(spacing: 8) {
-                                Button {
-                                    addLetterViewModel.showConfirmationDialog = true
-                                } label: {
-                                    Image(systemName: "envelope.open.fill")
-                                        .padding()
-                                        .frame(width: 100, height: 100)
-                                        .background(
-                                            Color.gray.opacity(0.2),
-                                            in: RoundedRectangle(cornerRadius: 10, style: .continuous)
-                                        )
-                                }
-
-                                ForEach(0..<addLetterViewModel.images.count, id: \.self) { index in
-                                    ZStack {
-                                        Button {
-                                            addLetterViewModel.showLetterImageFullScreenView = true
-                                        } label: {
-                                            Image(uiImage: addLetterViewModel.images[index])
-                                                .resizable()
-                                                .scaledToFill()
-                                                .frame(width: 100, height: 100)
-                                                .clipShape(RoundedRectangle(cornerRadius: 10))
-                                        }
-                                        VStack {
-                                            HStack {
-                                                Spacer()
-                                                Button {
-                                                    withAnimation {
-                                                        addLetterViewModel.removeImage(at: index)
-                                                    }
-                                                } label: {
-                                                    Image(systemName: "x.circle")
-                                                }
-                                                .padding(4)
-                                            }
-                                            Spacer()
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                        .scrollIndicators(.never)
-
-                        Text("편지 내용")
-
-                        TextEditor(text: $addLetterViewModel.text)
-                            .scrollContentBackground(.hidden)
-                            .padding()
-                            .lineSpacing(5)
-                            .frame(maxWidth: .infinity)
-                            .frame(height: 280)
-                            .background(
-                                RoundedRectangle(cornerRadius: 10)
-                                    .stroke(Color(hex: 0x807E79), lineWidth: 1)
-                            )
-                            .focused($focusField, equals: .text)
+                        letterTextSection
                     }
                     .padding()
                 }
@@ -142,9 +61,12 @@ struct AddLetterView: View {
                 LetterImageFullScreenView(images: addLetterViewModel.images)
             }
             .sheet(isPresented: $addLetterViewModel.showUIImagePicker, content: {
-                UIImagePicker(sourceType: addLetterViewModel.imagePickerSourceType, selectedImages: $addLetterViewModel.images, text: $addLetterViewModel.text)
+                UIImagePicker(sourceType: addLetterViewModel.imagePickerSourceType,
+                              selectedImages: $addLetterViewModel.images,
+                              text: $addLetterViewModel.text)
             })
-            .confirmationDialog("편지 사진 가져오기", isPresented: $addLetterViewModel.showConfirmationDialog) {
+            .confirmationDialog("편지 사진 가져오기", 
+                                isPresented: $addLetterViewModel.showConfirmationDialog) {
                 Button("카메라") {
                     addLetterViewModel.imagePickerSourceType = .camera
                     addLetterViewModel.showUIImagePicker = true
@@ -162,6 +84,107 @@ struct AddLetterView: View {
                 Text("편지 사진 가져오기")
             }
         }
+    }
+}
+
+// MARK: - Computed Properties
+
+extension AddLetterView {
+    @ViewBuilder
+    private var letterInfoSection: some View {
+        Text("보내는 사람")
+
+        TextField("", text: $addLetterViewModel.sender)
+            .padding()
+            .background(
+                RoundedRectangle(cornerRadius: 10)
+                    .stroke(Color(hex: 0x807E79), lineWidth: 1)
+            )
+            .focused($focusField, equals: .sender)
+
+        Text("받는 사람")
+
+        TextField("", text: $addLetterViewModel.receiver)
+            .padding()
+            .background(
+                RoundedRectangle(cornerRadius: 10)
+                    .stroke(Color(hex: 0x807E79), lineWidth: 1)
+            )
+            .focused($focusField, equals: .receiver)
+
+        Text("편지 날짜")
+
+        DatePicker("날짜", selection: $addLetterViewModel.date, displayedComponents: .date)
+            .labelsHidden()
+            .environment(\.locale, Locale.init(identifier: "ko"))
+    }
+
+    @ViewBuilder
+    private var letterImagesSection: some View {
+        Text("편지 사진")
+
+        ScrollView(.horizontal) {
+            HStack(spacing: 8) {
+                Button {
+                    addLetterViewModel.showConfirmationDialog = true
+                } label: {
+                    Image(systemName: "envelope.open.fill")
+                        .padding()
+                        .frame(width: 100, height: 100)
+                        .background(
+                            Color.gray.opacity(0.2),
+                            in: RoundedRectangle(cornerRadius: 10)
+                        )
+                }
+
+                ForEach(0..<addLetterViewModel.images.count, id: \.self) { index in
+                    ZStack {
+                        Button {
+                            addLetterViewModel.showLetterImageFullScreenView = true
+                        } label: {
+                            Image(uiImage: addLetterViewModel.images[index])
+                                .resizable()
+                                .scaledToFill()
+                                .frame(width: 100, height: 100)
+                                .clipShape(RoundedRectangle(cornerRadius: 10))
+                        }
+                        VStack {
+                            HStack {
+                                Spacer()
+
+                                Button {
+                                    withAnimation {
+                                        addLetterViewModel.removeImage(at: index)
+                                    }
+                                } label: {
+                                    Image(systemName: "x.circle")
+                                }
+                                .padding(4)
+                            }
+                            Spacer()
+                        }
+                    }
+                }
+            }
+        }
+        .scrollIndicators(.never)
+    }
+
+    @ViewBuilder
+    private var letterTextSection: some View {
+        Text("편지 내용")
+
+        TextEditor(text: $addLetterViewModel.text)
+            .scrollContentBackground(.hidden)
+            .padding()
+            .lineSpacing(5)
+            .frame(maxWidth: .infinity)
+            .frame(height: 280)
+            .background(
+                RoundedRectangle(cornerRadius: 10)
+                    .stroke(Color(hex: 0x807E79), lineWidth: 1)
+            )
+            .focused($focusField, equals: .text)
     }
 }
 

--- a/PJ3T3_Postie/Core/Home/View/AddLetterView.swift
+++ b/PJ3T3_Postie/Core/Home/View/AddLetterView.swift
@@ -11,10 +11,88 @@ struct AddLetterView: View {
     @StateObject private var addLetterViewModel = AddLetterViewModel()
 
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        ZStack {
+            Color(hex: 0xF5F1E8)
+                .ignoresSafeArea()
+
+            ScrollView {
+                VStack(alignment: .leading) {
+                    Text("보내는 사람")
+
+                    TextField("", text: $addLetterViewModel.sender)
+                        .padding()
+                        .background(
+                            RoundedRectangle(cornerRadius: 10)
+                                .stroke(Color(hex: 0x807E79), lineWidth: 1)
+                        )
+
+                    Text("받는 사람")
+
+                    TextField("", text: $addLetterViewModel.sender)
+                        .padding()
+                        .background(
+                            RoundedRectangle(cornerRadius: 10)
+                                .stroke(Color(hex: 0x807E79), lineWidth: 1)
+                        )
+
+                    Text("편지 날짜")
+
+                    DatePicker("날짜", selection: $addLetterViewModel.date, displayedComponents: .date)
+                        .labelsHidden()
+                        .environment(\.locale, Locale.init(identifier: "ko"))
+
+                    Text("편지 사진")
+
+                    ScrollView(.horizontal) {
+                        HStack(spacing: 8) {
+                            Button {
+                                // showConfirmationDialog
+                            } label: {
+                                Image(systemName: "envelope.open.fill")
+                                    .padding()
+                                    .frame(width: 100, height: 100)
+                                    .background(
+                                        Color.gray.opacity(0.2),
+                                        in: RoundedRectangle(cornerRadius: 10, style: .continuous)
+                                    )
+                            }
+                        }
+                    }
+                    .scrollIndicators(.never)
+                    
+                    Text("편지 내용")
+                    
+                    TextEditor(text: $addLetterViewModel.text)
+                        .scrollContentBackground(.hidden)
+                        .padding()
+                        .lineSpacing(5)
+                        .frame(maxWidth: .infinity)
+                        .frame(height: 280)
+                        .background(
+                            RoundedRectangle(cornerRadius: 10)
+                                .stroke(Color(hex: 0x807E79), lineWidth: 1)
+                        )
+                }
+                .padding()
+            }
+        }
+        .navigationTitle("편지 등록")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbarBackground(Color(hex: 0xF5F1E8), for: .navigationBar)
+        .toolbar {
+            ToolbarItemGroup(placement: .topBarTrailing) {
+                Button {
+                    // 편지 저장하기
+                } label : {
+                    Text("완료")
+                }
+            }
+        }
     }
 }
 
 #Preview {
-    AddLetterView()
+    NavigationStack {
+        AddLetterView()
+    }
 }

--- a/PJ3T3_Postie/Core/Home/View/AddLetterView.swift
+++ b/PJ3T3_Postie/Core/Home/View/AddLetterView.swift
@@ -111,6 +111,9 @@ struct AddLetterView: View {
                     }
                 }
             }
+            .sheet(isPresented: $addLetterViewModel.showUIImagePicker, content: {
+                UIImagePicker(sourceType: addLetterViewModel.imagePickerSourceType, selectedImages: $addLetterViewModel.images)
+            })
             .confirmationDialog("편지 사진 가져오기", isPresented: $addLetterViewModel.showConfirmationDialog) {
                 Button("카메라") {
                     addLetterViewModel.imagePickerSourceType = .camera

--- a/PJ3T3_Postie/Core/Home/View/AddLetterView.swift
+++ b/PJ3T3_Postie/Core/Home/View/AddLetterView.swift
@@ -58,7 +58,7 @@ struct AddLetterView: View {
                         ScrollView(.horizontal) {
                             HStack(spacing: 8) {
                                 Button {
-                                    // showConfirmationDialog
+                                    addLetterViewModel.showConfirmationDialog = true
                                 } label: {
                                     Image(systemName: "envelope.open.fill")
                                         .padding()
@@ -103,7 +103,6 @@ struct AddLetterView: View {
             .navigationBarTitleDisplayMode(.inline)
             .toolbarBackground(Color(hex: 0xF5F1E8), for: .navigationBar)
             .toolbar {
-
                 ToolbarItemGroup(placement: .topBarTrailing) {
                     Button {
                         // 편지 저장하기
@@ -111,7 +110,23 @@ struct AddLetterView: View {
                         Text("완료")
                     }
                 }
+            }
+            .confirmationDialog("편지 사진 가져오기", isPresented: $addLetterViewModel.showConfirmationDialog) {
+                Button("카메라") {
+                    addLetterViewModel.imagePickerSourceType = .camera
+                    addLetterViewModel.showUIImagePicker = true
+                }
 
+                Button("앨범") {
+                    addLetterViewModel.imagePickerSourceType = .photoLibrary
+                    addLetterViewModel.showUIImagePicker = true
+                }
+
+                Button("스캐너") {
+
+                }
+            } message: {
+                Text("편지 사진 가져오기")
             }
         }
     }

--- a/PJ3T3_Postie/Core/Home/View/AddLetterView.swift
+++ b/PJ3T3_Postie/Core/Home/View/AddLetterView.swift
@@ -72,7 +72,7 @@ struct AddLetterView: View {
                                 ForEach(0..<addLetterViewModel.images.count, id: \.self) { index in
                                     ZStack {
                                         Button {
-                                            // show letterImageView
+                                            addLetterViewModel.showLetterImageFullScreenView = true
                                         } label: {
                                             Image(uiImage: addLetterViewModel.images[index])
                                                 .resizable()
@@ -138,6 +138,9 @@ struct AddLetterView: View {
                         Text("완료")
                     }
                 }
+            }
+            .fullScreenCover(isPresented: $addLetterViewModel.showLetterImageFullScreenView) {
+                LetterImageFullScreenView(images: addLetterViewModel.images)
             }
             .sheet(isPresented: $addLetterViewModel.showUIImagePicker, content: {
                 UIImagePicker(sourceType: addLetterViewModel.imagePickerSourceType, selectedImages: $addLetterViewModel.images)

--- a/PJ3T3_Postie/Core/Home/View/AddLetterView.swift
+++ b/PJ3T3_Postie/Core/Home/View/AddLetterView.swift
@@ -60,12 +60,20 @@ struct AddLetterView: View {
             .fullScreenCover(isPresented: $addLetterViewModel.showLetterImageFullScreenView) {
                 LetterImageFullScreenView(images: addLetterViewModel.images)
             }
-            .sheet(isPresented: $addLetterViewModel.showUIImagePicker, content: {
-                UIImagePicker(sourceType: addLetterViewModel.imagePickerSourceType,
-                              selectedImages: $addLetterViewModel.images,
-                              text: $addLetterViewModel.text)
-            })
-            .confirmationDialog("편지 사진 가져오기", 
+            .sheet(isPresented: $addLetterViewModel.showUIImagePicker) {
+                UIImagePicker(
+                    sourceType: addLetterViewModel.imagePickerSourceType,
+                    selectedImages: $addLetterViewModel.images,
+                    text: $addLetterViewModel.text,
+                    showTextRecognizerErrorAlert: $addLetterViewModel.showTextRecognizerErrorAlert
+                )
+            }
+            .alert("문자 인식 실패", isPresented: $addLetterViewModel.showTextRecognizerErrorAlert) {
+
+            } message: {
+                Text("문자 인식에 실패했습니다. 다시 시도해 주세요.")
+            }
+            .confirmationDialog("편지 사진 가져오기",
                                 isPresented: $addLetterViewModel.showConfirmationDialog) {
                 Button("카메라") {
                     addLetterViewModel.showUIImagePicker(sourceType: .camera)

--- a/PJ3T3_Postie/Core/Home/View/LetterImageFullScreenView.swift
+++ b/PJ3T3_Postie/Core/Home/View/LetterImageFullScreenView.swift
@@ -1,0 +1,40 @@
+//
+//  LetterImageFullScreenView.swift
+//  PJ3T3_Postie
+//
+//  Created by KHJ on 2024/01/17.
+//
+
+import SwiftUI
+
+struct LetterImageFullScreenView: View {
+    let images: [UIImage]
+
+    @Environment(\.dismiss) var dismiss
+
+    var body: some View {
+        NavigationStack {
+            TabView {
+                ForEach(0..<images.count, id: \.self) { index in
+                    Image(uiImage: images[index])
+                        .resizable()
+                        .scaledToFit()
+                }
+            }
+            .tabViewStyle(.page)
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button {
+                        dismiss()
+                    } label: {
+                        Image(systemName: "xmark")
+                    }
+                }
+            }
+        }
+    }
+}
+
+//#Preview {
+//    LetterImageFullScreenView()
+//}

--- a/PJ3T3_Postie/Core/Home/View/UIImagePicker.swift
+++ b/PJ3T3_Postie/Core/Home/View/UIImagePicker.swift
@@ -23,10 +23,8 @@ struct UIImagePicker: UIViewControllerRepresentable {
         return imagePicker
     }
     
-    func updateUIViewController(_ uiViewController: UIImagePickerController, context: Context) {
+    func updateUIViewController(_ uiViewController: UIImagePickerController, context: Context) { }
 
-    }
-    
     class Coordinator: NSObject, UIImagePickerControllerDelegate, UINavigationControllerDelegate {
         var parent: UIImagePicker
 

--- a/PJ3T3_Postie/Core/Home/View/UIImagePicker.swift
+++ b/PJ3T3_Postie/Core/Home/View/UIImagePicker.swift
@@ -34,7 +34,10 @@ struct UIImagePicker: UIViewControllerRepresentable {
             self.parent = parent
         }
 
-        func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
+        func imagePickerController(
+            _ picker: UIImagePickerController,
+            didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]
+        ) {
 
             if let image = info[UIImagePickerController.InfoKey.originalImage] as? UIImage {
 

--- a/PJ3T3_Postie/Core/Home/View/UIImagePicker.swift
+++ b/PJ3T3_Postie/Core/Home/View/UIImagePicker.swift
@@ -12,6 +12,7 @@ struct UIImagePicker: UIViewControllerRepresentable {
 
     @Environment(\.dismiss) var dismiss
     @Binding var selectedImages: [UIImage]
+    @Binding var text: String
 
     func makeUIViewController(context: Context) -> UIImagePickerController {
         let imagePicker = UIImagePickerController()
@@ -34,10 +35,14 @@ struct UIImagePicker: UIViewControllerRepresentable {
         }
 
         func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
+
             if let image = info[UIImagePickerController.InfoKey.originalImage] as? UIImage {
-                // text 인식
+
+                let recognizer = TextRecognizer(selectedImage: image)
+                recognizer.recognizeText()
 
                 self.parent.selectedImages.append(image)
+                self.parent.text.append(" \(recognizer.recognizedText)")
             }
             parent.dismiss()
         }

--- a/PJ3T3_Postie/Core/Home/View/UIImagePicker.swift
+++ b/PJ3T3_Postie/Core/Home/View/UIImagePicker.swift
@@ -13,6 +13,7 @@ struct UIImagePicker: UIViewControllerRepresentable {
     @Environment(\.dismiss) var dismiss
     @Binding var selectedImages: [UIImage]
     @Binding var text: String
+    @Binding var showTextRecognizerErrorAlert: Bool
 
     func makeUIViewController(context: Context) -> UIImagePickerController {
         let imagePicker = UIImagePickerController()
@@ -38,15 +39,20 @@ struct UIImagePicker: UIViewControllerRepresentable {
         ) {
 
             if let image = info[UIImagePickerController.InfoKey.originalImage] as? UIImage {
+                self.parent.selectedImages.append(image)
 
                 let recognizer = TextRecognizer(selectedImage: image)
-                recognizer.recognizeText()
 
-                self.parent.selectedImages.append(image)
-                if self.parent.text == "사진을 등록하면 자동으로 편지 내용이 입력됩니다." {
-                    self.parent.text = recognizer.recognizedText
-                } else {
-                    self.parent.text.append(" \(recognizer.recognizedText)")
+                do {
+                    try recognizer.recognizeText()
+
+                    if self.parent.text == "사진을 등록하면 자동으로 편지 내용이 입력됩니다." {
+                        self.parent.text = recognizer.recognizedText
+                    } else {
+                        self.parent.text.append(" \(recognizer.recognizedText)")
+                    }
+                } catch {
+                    parent.showTextRecognizerErrorAlert = true
                 }
             }
             parent.dismiss()

--- a/PJ3T3_Postie/Core/Home/View/UIImagePicker.swift
+++ b/PJ3T3_Postie/Core/Home/View/UIImagePicker.swift
@@ -42,7 +42,11 @@ struct UIImagePicker: UIViewControllerRepresentable {
                 recognizer.recognizeText()
 
                 self.parent.selectedImages.append(image)
-                self.parent.text.append(" \(recognizer.recognizedText)")
+                if self.parent.text == "사진을 등록하면 자동으로 편지 내용이 입력됩니다." {
+                    self.parent.text = recognizer.recognizedText
+                } else {
+                    self.parent.text.append(" \(recognizer.recognizedText)")
+                }
             }
             parent.dismiss()
         }

--- a/PJ3T3_Postie/Core/Home/View/UIImagePicker.swift
+++ b/PJ3T3_Postie/Core/Home/View/UIImagePicker.swift
@@ -1,0 +1,49 @@
+//
+//  UIImagePicker.swift
+//  PJ3T3_Postie
+//
+//  Created by KHJ on 2024/01/17.
+//
+
+import SwiftUI
+
+struct UIImagePicker: UIViewControllerRepresentable {
+    var sourceType: UIImagePickerController.SourceType = .camera
+
+    @Environment(\.dismiss) var dismiss
+    @Binding var selectedImages: [UIImage]
+
+    func makeUIViewController(context: Context) -> UIImagePickerController {
+        let imagePicker = UIImagePickerController()
+        imagePicker.allowsEditing = false
+        imagePicker.sourceType = sourceType
+        imagePicker.delegate = context.coordinator
+
+        return imagePicker
+    }
+    
+    func updateUIViewController(_ uiViewController: UIImagePickerController, context: Context) {
+
+    }
+    
+    class Coordinator: NSObject, UIImagePickerControllerDelegate, UINavigationControllerDelegate {
+        var parent: UIImagePicker
+
+        init(_ parent: UIImagePicker) {
+            self.parent = parent
+        }
+
+        func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
+            if let image = info[UIImagePickerController.InfoKey.originalImage] as? UIImage {
+                // text 인식
+
+                self.parent.selectedImages.append(image)
+            }
+            parent.dismiss()
+        }
+    }
+    
+    func makeCoordinator() -> Coordinator {
+        Coordinator(self)
+    }
+}

--- a/PJ3T3_Postie/Core/Home/ViewModel/AddLetterViewModel.swift
+++ b/PJ3T3_Postie/Core/Home/ViewModel/AddLetterViewModel.swift
@@ -1,0 +1,12 @@
+//
+//  AddLetterViewModel.swift
+//  PJ3T3_Postie
+//
+//  Created by KHJ on 2024/01/17.
+//
+
+import Foundation
+
+class AddLetterViewModel: ObservableObject {
+    
+}

--- a/PJ3T3_Postie/Core/Home/ViewModel/AddLetterViewModel.swift
+++ b/PJ3T3_Postie/Core/Home/ViewModel/AddLetterViewModel.swift
@@ -17,7 +17,8 @@ class AddLetterViewModel: ObservableObject {
     @Published var showUIImagePicker = false
     @Published var images: [UIImage] = []
     @Published var showLetterImageFullScreenView: Bool = false
-    
+    @Published var showTextRecognizerErrorAlert: Bool = false
+
     private(set) var imagePickerSourceType: UIImagePickerController.SourceType = .camera
 
     func removeImage(at index: Int) {

--- a/PJ3T3_Postie/Core/Home/ViewModel/AddLetterViewModel.swift
+++ b/PJ3T3_Postie/Core/Home/ViewModel/AddLetterViewModel.swift
@@ -16,7 +16,8 @@ class AddLetterViewModel: ObservableObject {
     @Published var showConfirmationDialog: Bool = false
     @Published var showUIImagePicker = false
     @Published var images: [UIImage] = []
-
+    @Published var showLetterImageFullScreenView: Bool = false
+    
     var imagePickerSourceType: UIImagePickerController.SourceType = .camera
     
     func removeImage(at index: Int) {

--- a/PJ3T3_Postie/Core/Home/ViewModel/AddLetterViewModel.swift
+++ b/PJ3T3_Postie/Core/Home/ViewModel/AddLetterViewModel.swift
@@ -6,10 +6,15 @@
 //
 
 import Foundation
+import UIKit
 
 class AddLetterViewModel: ObservableObject {
     @Published var sender: String = ""
     @Published var receiver: String = ""
     @Published var date: Date = .now
     @Published var text: String = "사진을 등록하면 자동으로 편지 내용이 입력됩니다."
+    @Published var showConfirmationDialog: Bool = false
+    @Published var showUIImagePicker = false
+
+    var imagePickerSourceType: UIImagePickerController.SourceType = .camera
 }

--- a/PJ3T3_Postie/Core/Home/ViewModel/AddLetterViewModel.swift
+++ b/PJ3T3_Postie/Core/Home/ViewModel/AddLetterViewModel.swift
@@ -18,4 +18,8 @@ class AddLetterViewModel: ObservableObject {
     @Published var images: [UIImage] = []
 
     var imagePickerSourceType: UIImagePickerController.SourceType = .camera
+    
+    func removeImage(at index: Int) {
+        images.remove(at: index)
+    }
 }

--- a/PJ3T3_Postie/Core/Home/ViewModel/AddLetterViewModel.swift
+++ b/PJ3T3_Postie/Core/Home/ViewModel/AddLetterViewModel.swift
@@ -23,4 +23,9 @@ class AddLetterViewModel: ObservableObject {
     func removeImage(at index: Int) {
         images.remove(at: index)
     }
+
+    func showUIImagePicker(sourceType: UIImagePickerController.SourceType) {
+        imagePickerSourceType = sourceType
+        showUIImagePicker = true 
+    }
 }

--- a/PJ3T3_Postie/Core/Home/ViewModel/AddLetterViewModel.swift
+++ b/PJ3T3_Postie/Core/Home/ViewModel/AddLetterViewModel.swift
@@ -18,8 +18,8 @@ class AddLetterViewModel: ObservableObject {
     @Published var images: [UIImage] = []
     @Published var showLetterImageFullScreenView: Bool = false
     
-    var imagePickerSourceType: UIImagePickerController.SourceType = .camera
-    
+    private(set) var imagePickerSourceType: UIImagePickerController.SourceType = .camera
+
     func removeImage(at index: Int) {
         images.remove(at: index)
     }

--- a/PJ3T3_Postie/Core/Home/ViewModel/AddLetterViewModel.swift
+++ b/PJ3T3_Postie/Core/Home/ViewModel/AddLetterViewModel.swift
@@ -8,5 +8,8 @@
 import Foundation
 
 class AddLetterViewModel: ObservableObject {
-    
+    @Published var sender: String = ""
+    @Published var receiver: String = ""
+    @Published var date: Date = .now
+    @Published var text: String = "사진을 등록하면 자동으로 편지 내용이 입력됩니다."
 }

--- a/PJ3T3_Postie/Core/Home/ViewModel/AddLetterViewModel.swift
+++ b/PJ3T3_Postie/Core/Home/ViewModel/AddLetterViewModel.swift
@@ -15,6 +15,7 @@ class AddLetterViewModel: ObservableObject {
     @Published var text: String = "사진을 등록하면 자동으로 편지 내용이 입력됩니다."
     @Published var showConfirmationDialog: Bool = false
     @Published var showUIImagePicker = false
+    @Published var images: [UIImage] = []
 
     var imagePickerSourceType: UIImagePickerController.SourceType = .camera
 }

--- a/PJ3T3_Postie/Core/Home/ViewModel/TextRecognizer.swift
+++ b/PJ3T3_Postie/Core/Home/ViewModel/TextRecognizer.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import SwiftUI
 import UIKit
 import Vision
 
@@ -19,7 +20,7 @@ class TextRecognizer {
     
     /// Vision 프레임워크를 사용해 사용자가 가져온 이미지에서 텍스트를 인식합니다.
     /// 인식이 끝나면 VNRecognizeTextRquest의 completionHandler가 호출됩니다.
-    func recognizeText() {
+    func recognizeText() throws {
         guard let cgImage = selectedImage.cgImage else { return }
 
         let requestHandler = VNImageRequestHandler(cgImage: cgImage)
@@ -29,11 +30,7 @@ class TextRecognizer {
         request.recognitionLevel = .accurate
         request.usesLanguageCorrection = true
 
-        do {
-            try requestHandler.perform([request])
-        } catch {
-
-        }
+        try requestHandler.perform([request])
     }
     
     /// 이미지에서 인식된 텍스트 값으로 TextRecognizer 인스턴스의 recognizedText 변수를 업데이트 합니다.

--- a/PJ3T3_Postie/Core/Home/ViewModel/TextRecognizer.swift
+++ b/PJ3T3_Postie/Core/Home/ViewModel/TextRecognizer.swift
@@ -22,7 +22,7 @@ class TextRecognizer {
 
         let requestHandler = VNImageRequestHandler(cgImage: cgImage)
 
-        let request = VNRecognizeTextRequest()
+        let request = VNRecognizeTextRequest(completionHandler: recognizeTextHandler)
         request.recognitionLanguages = ["ko-KR"]
         request.recognitionLevel = .accurate
         request.usesLanguageCorrection = true

--- a/PJ3T3_Postie/Core/Home/ViewModel/TextRecognizer.swift
+++ b/PJ3T3_Postie/Core/Home/ViewModel/TextRecognizer.swift
@@ -16,7 +16,9 @@ class TextRecognizer {
     init(selectedImage: UIImage) {
         self.selectedImage = selectedImage
     }
-
+    
+    /// Vision 프레임워크를 사용해 사용자가 가져온 이미지에서 텍스트를 인식합니다.
+    /// 인식이 끝나면 VNRecognizeTextRquest의 completionHandler가 호출됩니다.
     func recognizeText() {
         guard let cgImage = selectedImage.cgImage else { return }
 
@@ -33,7 +35,8 @@ class TextRecognizer {
 
         }
     }
-
+    
+    /// 이미지에서 인식된 텍스트 값으로 TextRecognizer 인스턴스의 recognizedText 변수를 업데이트 합니다.
     private func recognizeTextHandler(request: VNRequest, error: Error?) {
         guard let observations = request.results as? [VNRecognizedTextObservation] else { return }
 

--- a/PJ3T3_Postie/Core/Home/ViewModel/TextRecognizer.swift
+++ b/PJ3T3_Postie/Core/Home/ViewModel/TextRecognizer.swift
@@ -1,0 +1,44 @@
+//
+//  TextRecognizer.swift
+//  PJ3T3_Postie
+//
+//  Created by KHJ on 2024/01/17.
+//
+
+import Foundation
+import UIKit
+import Vision
+
+class TextRecognizer {
+    let selectedImage: UIImage
+    var recognizedText = ""
+
+    init(selectedImage: UIImage) {
+        self.selectedImage = selectedImage
+    }
+
+    func recognizeText() {
+        guard let cgImage = selectedImage.cgImage else { return }
+
+        let requestHandler = VNImageRequestHandler(cgImage: cgImage)
+
+        let request = VNRecognizeTextRequest()
+        request.recognitionLanguages = ["ko-KR"]
+        request.recognitionLevel = .accurate
+        request.usesLanguageCorrection = true
+
+        do {
+            try requestHandler.perform([request])
+        } catch {
+
+        }
+    }
+
+    private func recognizeTextHandler(request: VNRequest, error: Error?) {
+        guard let observations = request.results as? [VNRecognizedTextObservation] else { return }
+
+        recognizedText = observations.compactMap {
+            $0.topCandidates(1).first?.string
+        }.joined(separator: "\n")
+    }
+}

--- a/PJ3T3_Postie/Extenstions/Color.swift
+++ b/PJ3T3_Postie/Extenstions/Color.swift
@@ -5,4 +5,16 @@
 //  Created by Eunsu JEONG on 1/17/24.
 //
 
-import Foundation
+import SwiftUI
+
+extension Color {
+    init(hex: UInt, alpha: Double = 1) {
+        self.init(
+            .sRGB,
+            red: Double((hex >> 16) & 0xff) / 255,
+            green: Double((hex >> 08) & 0xff) / 255,
+            blue: Double((hex >> 00) & 0xff) / 255,
+            opacity: alpha
+        )
+    }
+}


### PR DESCRIPTION
## 개요
- 연관 이슈 #8 #9  #14  #19 
- AddLetterView UI 구현 및 뷰모델 생성 
- AddLetterView 이미지 불러오기 구현 
- 불러온 이미지 텍스트 인식 구현

## 변경 사항
- 편지 등록하는 뷰 UI 구현하고 뷰모델로 필요한 변수 뺐습니다. 
- 편지 이미지 불러오는 건 UIImagePicker를 사용해 카메라, 앨범 두 곳에서 불러오도록 했습니다. 
- 텍스트 인식은 TextRecognizer라는 클래스를 생성하고 UIImagePicker에서 미디어 선택이 끝나면 함수가 호출되도록 했습니다. 
- 저번 처럼 Color Extension에서 hex값으로 Color 뷰를 생성할 수 있도록 코드 추가했습니다. 

<!-- 이미지 가로 크기 216 고정 -->
## 스크린샷
|제목|작업 전|작업 후|
|:-:|:-:|:-:| 
|AddLetterView||<img width="216" alt="image" src="https://github.com/APP-iOS3rd/PJ3T3_Postie/assets/119300554/6334b016-6b61-4da1-a0bf-3a36c8bd84ef">|

<!-- 질문, 중점적으로 확인받고 싶은 내용 또는 주의사항 등 자유로운 전달사항 적어주세요. -->
## 전달사항( 질문사항 ) 
- confirmationDialog 부분에서 imagePicker source와 showImagePicker Bool 값을 수정하는 코드를 뷰 내부에 적었는데 이런 것들도 뷰모델로 옮겨 함수 하나로 바꾸는 게 좋을 지 궁금합니다. 
- 다음 부터는 PR 코드 리뷰 양을 조금 줄여보겠습니다.. 혹시 코드 양이 어떤지 말씀 부탁드려요.
- 스캐너는 이후에 추가 해보려고 합니다. 
- 한 줄 요약란은 일단 없애고 진행했습니다. 