### PR TITLE
Email 로그인, 로그아웃 기능 구현

### DIFF
--- a/PJ3T3_Postie/Core/Login/View/LoginView.swift
+++ b/PJ3T3_Postie/Core/Login/View/LoginView.swift
@@ -52,7 +52,9 @@ struct LoginView: View {
 
                     //Sign in Button
                     Button {
-                        print(#function)
+                        Task {
+                            try await authViewModel.signIn(withEamil: email, password: password)
+                        }
                     } label: {
                         HStack {
                             Text("SIGN IN")

--- a/PJ3T3_Postie/Core/Login/View/LoginView.swift
+++ b/PJ3T3_Postie/Core/Login/View/LoginView.swift
@@ -94,6 +94,15 @@ struct LoginView: View {
     }
 }
 
+extension LoginView: AuthenticationProtocol {
+    var formIsValid: Bool {
+        return !email.isEmpty
+        && email.contains("@")
+        && !password.isEmpty
+        && password.count > 5
+    }
+}
+
 #Preview {
     LoginView()
 }

--- a/PJ3T3_Postie/Core/Login/View/LoginView.swift
+++ b/PJ3T3_Postie/Core/Login/View/LoginView.swift
@@ -67,6 +67,8 @@ struct LoginView: View {
                                height: 48)
                     }
                     .background(buttonColor)
+                    .disabled(!formIsValid)
+                    .opacity(formIsValid ? 1.0 : 0.5)
                     .clipShape(RoundedRectangle(cornerRadius: 10))
                     .padding(.top, 24)
 

--- a/PJ3T3_Postie/Core/Login/View/LoginView.swift
+++ b/PJ3T3_Postie/Core/Login/View/LoginView.swift
@@ -14,6 +14,8 @@ struct LoginView: View {
     //버튼 width를 정하기 위해 screen size를 받아온다.
     @State private var screenWidth: CGFloat = 0
     private let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene
+    //ViewModels
+    @ObservedObject var authViewModel = AuthViewModel.shared
     //Colors
     private let viewBackground: Color = .white
     private let buttonColor: Color = Color(uiColor: .darkGray)

--- a/PJ3T3_Postie/Core/Login/View/LoginView.swift
+++ b/PJ3T3_Postie/Core/Login/View/LoginView.swift
@@ -11,11 +11,11 @@ struct LoginView: View {
     //Colors
     private let viewBackground: Color = .white
     private let buttonColor: Color = Color(uiColor: .darkGray)
+    //ViewModels
+    @ObservedObject var authViewModel = AuthViewModel.shared
     //TextFields의 input값을 하위뷰에 넘겨준다.
     @State private var email = ""
     @State private var password = ""
-    //ViewModels
-    @ObservedObject var authViewModel = AuthViewModel.shared
     
     var body: some View {
         NavigationStack {

--- a/PJ3T3_Postie/Core/Login/View/RegistrationView.swift
+++ b/PJ3T3_Postie/Core/Login/View/RegistrationView.swift
@@ -54,10 +54,25 @@ struct RegistrationView: View {
                               placeholder: "Enter your password",
                               isSecureField: true)
 
-                    LoginInputView(text: $confirmPassword,
-                              title: "Confirm password",
-                              placeholder: "Confirm your password",
-                              isSecureField: true)
+                    ZStack(alignment: .trailing) {
+                        LoginInputView(text: $confirmPassword,
+                                  title: "Confirm password",
+                                  placeholder: "Confirm your password",
+                                  isSecureField: true)
+                        if !password.isEmpty && !confirmPassword.isEmpty {
+                            if password == confirmPassword {
+                                Image(systemName: "checkmark.circle.fill")
+                                    .imageScale(.large)
+                                    .fontWeight(.bold)
+                                    .foregroundStyle(.green)
+                            } else {
+                                Image(systemName: "xamrk.circle.fill")
+                                    .imageScale(.large)
+                                    .fontWeight(.bold)
+                                    .foregroundStyle(.red)
+                            } //if...else
+                        } //if
+                    } //ZStack
                 } //VStack
                 .padding(.horizontal)
                 .padding(.top, 12)

--- a/PJ3T3_Postie/Core/Login/View/RegistrationView.swift
+++ b/PJ3T3_Postie/Core/Login/View/RegistrationView.swift
@@ -62,9 +62,11 @@ struct RegistrationView: View {
                 .padding(.horizontal)
                 .padding(.top, 12)
 
-                //Sign in Button
+                //Sign up Button
                 Button {
-                    print(#function)
+                    Task {
+                        try await authViewModel.createUser(withEamil: email, password: password, fullName: fullName)
+                    }
                 } label: {
                     HStack {
                         Text("SIGN UP")

--- a/PJ3T3_Postie/Core/Login/View/RegistrationView.swift
+++ b/PJ3T3_Postie/Core/Login/View/RegistrationView.swift
@@ -78,6 +78,8 @@ struct RegistrationView: View {
                     .frame(width: screenWidth - 32, height: 48)
                 }
                 .background(buttonColor)
+                .disabled(!formIsValid)
+                .opacity(formIsValid ? 1.0 : 0.5)
                 .clipShape(RoundedRectangle(cornerRadius: 10))
                 .padding(.top, 24)
 
@@ -99,6 +101,17 @@ struct RegistrationView: View {
                 screenWidth = windowScene?.screen.bounds.width ?? 1.0
             }
         } //ZStack
+    }
+}
+
+extension RegistrationView: AuthenticationProtocol {
+    var formIsValid: Bool {
+        return !email.isEmpty
+        && email.contains("@")
+        && !password.isEmpty
+        && password.count > 5
+        && password == confirmPassword
+        && !fullName.isEmpty
     }
 }
 

--- a/PJ3T3_Postie/Core/Login/View/RegistrationView.swift
+++ b/PJ3T3_Postie/Core/Login/View/RegistrationView.swift
@@ -18,6 +18,8 @@ struct RegistrationView: View {
     private let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene
     //뷰를 해제하는 기능 설정
     @Environment(\.dismiss) var dismiss
+    //ViewModels
+    @ObservedObject var authViewModel = AuthViewModel.shared
     //Colors
     private let viewBackground: Color = .white
     private let buttonColor: Color = Color(uiColor: .darkGray)

--- a/PJ3T3_Postie/Core/Login/View/RegistrationView.swift
+++ b/PJ3T3_Postie/Core/Login/View/RegistrationView.swift
@@ -66,7 +66,7 @@ struct RegistrationView: View {
                                     .fontWeight(.bold)
                                     .foregroundStyle(.green)
                             } else {
-                                Image(systemName: "xamrk.circle.fill")
+                                Image(systemName: "xmark.circle.fill")
                                     .imageScale(.large)
                                     .fontWeight(.bold)
                                     .foregroundStyle(.red)

--- a/PJ3T3_Postie/Core/Login/ViewModel/AuthViewModel.swift
+++ b/PJ3T3_Postie/Core/Login/ViewModel/AuthViewModel.swift
@@ -53,6 +53,10 @@ class AuthViewModel: ObservableObject {
 
             //5. Upload data to Firestore
             try await Firestore.firestore().collection("users").document(user.id).setData(encodedUser)
+            
+            //회원가입을 하면 userSession이 업데이트 되며 Firestore에 데이터를 저장하는데,
+            //userSession이 업데이트 됨에 따라 자동으로 Login 된 유저 뷰로 Navigate 되면, 업로드 된 Firestore의 데이터를 fetch해준다.
+            await fetchUser()
         } catch {
             //if anything goes wrong:
             print("DEBUG: Failed to create user with error \(error.localizedDescription)")

--- a/PJ3T3_Postie/Core/Login/ViewModel/AuthViewModel.swift
+++ b/PJ3T3_Postie/Core/Login/ViewModel/AuthViewModel.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+
 import FirebaseAuth
 import FirebaseFirestore
 

--- a/PJ3T3_Postie/Core/Login/ViewModel/AuthViewModel.swift
+++ b/PJ3T3_Postie/Core/Login/ViewModel/AuthViewModel.swift
@@ -9,6 +9,13 @@ import Foundation
 import FirebaseAuth
 import FirebaseFirestore
 
+//UI 업데이트는 꼭 메인 스레드에서 진행되어야 한다.
+//비동기 네트워킹은 기본적으로 메인이 아닌 다른 스레드에서 진행되므로
+//UI 업데이트를 하는 Publish가 만드시 메인 스레드에서 수행되도록 설정하기 위해 @MainActor를 선언해 주는 것이다.
+
+//Actor 내에서 구현이 실행중인 모든 작업은 항상 메인 큐에서 수행하게 된다.
+//Task 로 생성된 작업은 (메인 액터에서 생성되지 않는 한) 백그라운드 스레드에서 즉시 실행되며, await 키워드를 사용해서 완료된 값이 돌아올 때까지 기다릴 수 있다.
+@MainActor
 class AuthViewModel: ObservableObject {
     @Published var userSession: FirebaseAuth.User? //Firebase user object
     @Published var currentUser: User? //User Data Model

--- a/PJ3T3_Postie/Core/Login/ViewModel/AuthViewModel.swift
+++ b/PJ3T3_Postie/Core/Login/ViewModel/AuthViewModel.swift
@@ -12,8 +12,9 @@ import FirebaseFirestore
 class AuthViewModel: ObservableObject {
     @Published var userSession: FirebaseAuth.User? //Firebase user object
     @Published var currentUser: User? //User Data Model
-
-    init() {
+    static let shared = AuthViewModel()
+    
+    private init() {
 
     }
 

--- a/PJ3T3_Postie/Core/Login/ViewModel/AuthViewModel.swift
+++ b/PJ3T3_Postie/Core/Login/ViewModel/AuthViewModel.swift
@@ -15,7 +15,9 @@ class AuthViewModel: ObservableObject {
     static let shared = AuthViewModel()
     
     private init() {
-
+        //viewModel이 init될 때 이미 존재하는 user가 있는지 확인한다.
+        //이 기능은 Firebase에서 제공하는 기능으로 currentUser가 로그인을 했는지(한 상태인지)에 대한 정보를 디바이스에 캐시 데이터로 저장해 둔다.
+        self.userSession = Auth.auth().currentUser
     }
 
     func signIn(withEamil email: String, password: String) async throws {

--- a/PJ3T3_Postie/Core/Login/ViewModel/AuthViewModel.swift
+++ b/PJ3T3_Postie/Core/Login/ViewModel/AuthViewModel.swift
@@ -17,9 +17,9 @@ import FirebaseFirestore
 //Task 로 생성된 작업은 (메인 액터에서 생성되지 않는 한) 백그라운드 스레드에서 즉시 실행되며, await 키워드를 사용해서 완료된 값이 돌아올 때까지 기다릴 수 있다.
 @MainActor
 class AuthViewModel: ObservableObject {
+    static let shared = AuthViewModel()
     @Published var userSession: FirebaseAuth.User? //Firebase user object
     @Published var currentUser: User? //User Data Model
-    static let shared = AuthViewModel()
     
     private init() {
         //viewModel이 init될 때 이미 존재하는 user가 있는지 확인한다.
@@ -63,8 +63,15 @@ class AuthViewModel: ObservableObject {
         }
     }
 
+    //로그인 화면으로 돌아가고, back-end에서 로그아웃 되어야 한다.
     func signOut() {
-
+        do {
+            try Auth.auth().signOut() //Signs out user on backend
+            self.userSession = nil //userSession의 데이터가 사라지며 ContentView에서 Login하기 전 화면을 보여주게 된다.
+            self.currentUser = nil //데이터 모델을 초기화시켜 현재 유저의 데이터를 지운다.
+        } catch {
+            print("DEBUG: Failed to sign out with error \(error.localizedDescription)")
+        }
     }
 
     func deleteAccount() {

--- a/PJ3T3_Postie/Core/Login/ViewModel/AuthViewModel.swift
+++ b/PJ3T3_Postie/Core/Login/ViewModel/AuthViewModel.swift
@@ -32,7 +32,14 @@ class AuthViewModel: ObservableObject {
     }
 
     func signIn(withEamil email: String, password: String) async throws {
-        print(#function)
+        do {
+            let result = try await Auth.auth().signIn(withEmail: email, password: password)
+            self.userSession = result.user
+            //fetchUser가 uid로 firebase에서 데이터를 찾기 위해서는 반드시 signIn이 완료 된 다음 fetchUser 함수를 호출해야 한다.
+            await fetchUser()
+        } catch {
+            print("DEBUG: Failed to log in with error \(error.localizedDescription)")
+        }
     }
 
     func createUser(withEamil email: String, password: String, fullName: String) async throws {

--- a/PJ3T3_Postie/Core/Login/ViewModel/AuthViewModel.swift
+++ b/PJ3T3_Postie/Core/Login/ViewModel/AuthViewModel.swift
@@ -9,6 +9,11 @@ import Foundation
 import FirebaseAuth
 import FirebaseFirestore
 
+//로그인하는데 사용하는 Form마다 적용하여 Form의 내용이 유효한지 검증한다.
+protocol AuthenticationProtocol {
+    var formIsValid: Bool { get }
+}
+
 //UI 업데이트는 꼭 메인 스레드에서 진행되어야 한다.
 //비동기 네트워킹은 기본적으로 메인이 아닌 다른 스레드에서 진행되므로
 //UI 업데이트를 하는 Publish가 만드시 메인 스레드에서 수행되도록 설정하기 위해 @MainActor를 선언해 주는 것이다.

--- a/PJ3T3_Postie/Core/Login/ViewModel/AuthViewModel.swift
+++ b/PJ3T3_Postie/Core/Login/ViewModel/AuthViewModel.swift
@@ -25,6 +25,10 @@ class AuthViewModel: ObservableObject {
         //viewModel이 init될 때 이미 존재하는 user가 있는지 확인한다.
         //이 기능은 Firebase에서 제공하는 기능으로 currentUser가 로그인을 했는지(한 상태인지)에 대한 정보를 디바이스에 캐시 데이터로 저장해 둔다.
         self.userSession = Auth.auth().currentUser
+        
+        Task {
+            await fetchUser()
+        }
     }
 
     func signIn(withEamil email: String, password: String) async throws {
@@ -64,6 +68,11 @@ class AuthViewModel: ObservableObject {
     }
 
     func fetchUser() async {
-
+        //현재 로그인중인 유저가 있다면 fetch가 진행된다. 로그인 유저가 없다면 해당 guard문을 통과하지 못하고 return된다.
+        guard let uid = Auth.auth().currentUser?.uid else { return }
+        guard let snapshot = try? await Firestore.firestore().collection("users").document(uid).getDocument() else { return }
+        //Firestore에서 받은 데이터를 User model에 맞는 형태로 변환하여 currentUser에 값을 부여한다.
+        self.currentUser = try? snapshot.data(as: User.self)
+        print("DEBUG: Current user is \(self.currentUser)")
     }
 }

--- a/PJ3T3_Postie/Core/Login/ViewModel/AuthViewModel.swift
+++ b/PJ3T3_Postie/Core/Login/ViewModel/AuthViewModel.swift
@@ -6,3 +6,54 @@
 //
 
 import Foundation
+import FirebaseAuth
+import FirebaseFirestore
+
+class AuthViewModel: ObservableObject {
+    @Published var userSession: FirebaseAuth.User? //Firebase user object
+    @Published var currentUser: User? //User Data Model
+
+    init() {
+
+    }
+
+    func signIn(withEamil email: String, password: String) async throws {
+        print(#function)
+    }
+
+    func createUser(withEamil email: String, password: String, fullName: String) async throws {
+        do {
+            //1. Try to create user -> await its result -> store it to the property
+            let result = try await Auth.auth().createUser(withEmail: email, password: password)
+
+            //2. Once success, set userSession property
+            self.userSession = result.user //result에서 user값을 받아와 userSession에 넣어줌
+
+            //3. Create our User object
+            //firebase의 user는 firebase에서 새로운 user를 생성하고 uid 를 제공해준다.
+            //기타 사용자에게 얻고자 하는 데이터(예: 핸드폰 번호, 생일 등)가 있다면 User Model에 구성을 추가하고 input을 받아야 한다.
+            let user = User(id: result.user.uid, fullName: fullName, email: email)
+
+            //4. Encode the object throught the codable protocol
+            let encodedUser = try Firestore.Encoder().encode(user)
+
+            //5. Upload data to Firestore
+            try await Firestore.firestore().collection("users").document(user.id).setData(encodedUser)
+        } catch {
+            //if anything goes wrong:
+            print("DEBUG: Failed to create user with error \(error.localizedDescription)")
+        }
+    }
+
+    func signOut() {
+
+    }
+
+    func deleteAccount() {
+
+    }
+
+    func fetchUser() async {
+
+    }
+}

--- a/PJ3T3_Postie/Core/Root/ContentView.swift
+++ b/PJ3T3_Postie/Core/Root/ContentView.swift
@@ -13,6 +13,8 @@ struct ContentView: View {
     
     var body: some View {
         Group {
+            //ViewModel의 userSession이 Published로 구현되어 있기 때문에 해당 뷰에 업데이트가 발생하면 ContentView에 새로운 userSession값을 가지고 뷰를 재구성하도록 신호를 보낸다.
+            //ContentView는 viewModel에 업데이트가 없는지 listen하는 상태
             if authViewModel.userSession != nil {
                 //userSession이 있으면 SettingView를 보여줌
                 SettingView()

--- a/PJ3T3_Postie/Core/Root/ContentView.swift
+++ b/PJ3T3_Postie/Core/Root/ContentView.swift
@@ -8,14 +8,18 @@
 import SwiftUI
 
 struct ContentView: View {
+    //ViewModels
+    @ObservedObject var authViewModel = AuthViewModel.shared
+    
     var body: some View {
-        VStack {
-            Image(systemName: "globe")
-                .imageScale(.large)
-                .foregroundStyle(.tint)
-            Text("Hello, world!")
+        Group {
+            if authViewModel.userSession != nil {
+                //userSession이 있으면 SettingView를 보여줌
+                SettingView()
+            } else {
+                LoginView()
+            }
         }
-        .padding()
     }
 }
 

--- a/PJ3T3_Postie/Core/Setting/View/SettingView.swift
+++ b/PJ3T3_Postie/Core/Setting/View/SettingView.swift
@@ -66,7 +66,9 @@ struct SettingView: View {
                     }
                 } //Section
             } //List
-        } //if
+        } else {
+            ProgressView()
+        } //if...else
     }
 }
 

--- a/PJ3T3_Postie/Core/Setting/View/SettingView.swift
+++ b/PJ3T3_Postie/Core/Setting/View/SettingView.swift
@@ -11,58 +11,62 @@ struct SettingView: View {
     //Colors
     private let profileBackgroundColor: Color = .gray
     private let signOutIconColor: Color = Color(uiColor: .lightGray)
+    //ViewModels
+    @ObservedObject var authViewModel = AuthViewModel.shared
     
     var body: some View {
-        List {
-            Section {
-                HStack {
-                    Text(User.MOCK_USER.initials)
-                        .font(.title)
-                        .fontWeight(.semibold)
-                        .foregroundStyle(.white)
-                        .frame(width: 72, height: 72)
-                        .background(profileBackgroundColor)
-                        .clipShape(Circle())
-                    
-                    VStack(alignment: .leading, spacing: 4) {
-                        Text(User.MOCK_USER.fullName)
-                            .font(.subheadline)
+        if let user = authViewModel.currentUser {
+            List {
+                Section {
+                    HStack {
+                        Text(user.initials)
+                            .font(.title)
                             .fontWeight(.semibold)
-                            .padding(.top, 4)
+                            .foregroundStyle(.white)
+                            .frame(width: 72, height: 72)
+                            .background(profileBackgroundColor)
+                            .clipShape(Circle())
                         
-                        Text(User.MOCK_USER.email)
-                            .font(.footnote)
-                            .foregroundStyle(profileBackgroundColor)
-                    } //VStack
-                } //HStack
-            } //Section
-            
-            Section("General") {
-                HStack {
-                    SettingsRowView(imageName: "gear", title: "Version", tintColor: profileBackgroundColor)
-                    
-                    Spacer()
-                    
-                    Text("1.0.0")
-                        .font(.subheadline)
-                        .foregroundStyle(profileBackgroundColor)
-                }
-            } //Section
-            
-            Section("Account") {
-                Button {
-                    print("Sign out...")
-                } label: {
-                    SettingsRowView(imageName: "arrow.left.circle.fill", title: "Sign Out", tintColor: signOutIconColor)
-                }
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text(user.fullName)
+                                .font(.subheadline)
+                                .fontWeight(.semibold)
+                                .padding(.top, 4)
+                            
+                            Text(user.email)
+                                .font(.footnote)
+                                .foregroundStyle(profileBackgroundColor)
+                        } //VStack
+                    } //HStack
+                } //Section
                 
-                Button {
-                    print("Delete account")
-                } label: {
-                    SettingsRowView(imageName: "xmark.circle.fill", title: "Delete Account", tintColor: signOutIconColor)
-                }
-            } //Section
-        } //List
+                Section("General") {
+                    HStack {
+                        SettingsRowView(imageName: "gear", title: "Version", tintColor: profileBackgroundColor)
+                        
+                        Spacer()
+                        
+                        Text("1.0.0")
+                            .font(.subheadline)
+                            .foregroundStyle(profileBackgroundColor)
+                    }
+                } //Section
+                
+                Section("Account") {
+                    Button {
+                        print("Sign out...")
+                    } label: {
+                        SettingsRowView(imageName: "arrow.left.circle.fill", title: "Sign Out", tintColor: signOutIconColor)
+                    }
+                    
+                    Button {
+                        print("Delete account")
+                    } label: {
+                        SettingsRowView(imageName: "xmark.circle.fill", title: "Delete Account", tintColor: signOutIconColor)
+                    }
+                } //Section
+            } //List
+        } //if
     }
 }
 

--- a/PJ3T3_Postie/Core/Setting/View/SettingView.swift
+++ b/PJ3T3_Postie/Core/Setting/View/SettingView.swift
@@ -16,7 +16,7 @@ struct SettingView: View {
         List {
             Section {
                 HStack {
-                    Text("EJ")
+                    Text(User.MOCK_USER.initials)
                         .font(.title)
                         .fontWeight(.semibold)
                         .foregroundStyle(.white)
@@ -25,12 +25,12 @@ struct SettingView: View {
                         .clipShape(Circle())
                     
                     VStack(alignment: .leading, spacing: 4) {
-                        Text("Eunice Jeong")
+                        Text(User.MOCK_USER.fullName)
                             .font(.subheadline)
                             .fontWeight(.semibold)
                             .padding(.top, 4)
                         
-                        Text("test@test.com")
+                        Text(User.MOCK_USER.email)
                             .font(.footnote)
                             .foregroundStyle(profileBackgroundColor)
                     } //VStack

--- a/PJ3T3_Postie/Core/Setting/View/SettingView.swift
+++ b/PJ3T3_Postie/Core/Setting/View/SettingView.swift
@@ -54,7 +54,7 @@ struct SettingView: View {
                 
                 Section("Account") {
                     Button {
-                        print("Sign out...")
+                        authViewModel.signOut()
                     } label: {
                         SettingsRowView(imageName: "arrow.left.circle.fill", title: "Sign Out", tintColor: signOutIconColor)
                     }

--- a/PJ3T3_Postie/Model/User.swift
+++ b/PJ3T3_Postie/Model/User.swift
@@ -6,3 +6,23 @@
 //
 
 import Foundation
+
+struct User: Identifiable, Codable {
+    let id: String
+    let fullName: String
+    let email: String
+    
+    var initials: String {
+        let formatter = PersonNameComponentsFormatter()
+        if let components = formatter.personNameComponents(from: fullName) {
+            formatter.style = .abbreviated
+            return formatter.string(from: components)
+        }
+
+        return ""
+    }
+}
+
+extension User {
+    static var MOCK_USER = User(id: UUID().uuidString, fullName: "Eunice Jeong", email: "test@gmail.com")
+}

--- a/PJ3T3_Postie/Model/User.swift
+++ b/PJ3T3_Postie/Model/User.swift
@@ -7,6 +7,8 @@
 
 import Foundation
 
+//Decoding: Raw data나 Raw json 데이터를 받아 data object로 map해준다.
+//Encoding: data object를 json data로 변환한다.
 struct User: Identifiable, Codable {
     let id: String
     let fullName: String


### PR DESCRIPTION
<!-- 작업 동기에는 해당 작업을 수행한 이유 또는 목적을 간단히 적어주세요. -->
<!-- 연관 이슈는 진행중인 이슈, close에는 닫고싶은 issue를 적습니다. -->
## 개요
- 연관 이슈
- close #7 
- 작업 요약: Email을 사용한 로그인, 로그아웃 기능 구현을 완료하였습니다.

<!-- PR의 핵심이 되는 작업 내용을 적어주세요. -->
## 변경 사항
- FirebaseAuth를 사용해 email 계정을 생성하고 로그인, 로그아웃을 할 수 있습니다.
- 생성된 계정은 Firestore에 저장됩니다.
- 앱이 실행될 때(ViewModel이 init될 때) FirebaseAuth에 해당 유저가 아직 로그인중인지의 정보를 받아와 뷰를 보여줍니다.
- viewModel을 view에 적용하였습니다.
- 로그인 및 회원가입시 입력 받는 TextField의 유효성을 검증하는 프로토콜을 생성하였습니다.

<!-- 노션 팀 페이지에 정리한 글의 링크나 참고한 블로그의 링크를 남겨주세요. -->
## 공유사항(배운 것, 참고하면 좋을 것)
- https://youtu.be/QJHmhLGv-_0?si=AXycgxn2i8uMmUBP

<!-- 이미지 가로 크기 216 고정 -->
## 스크린샷
|제목|작업 전|작업 후|
|:-:|:-:|:-:| 
|비밀번호 검증 실패||<img width="216" alt="스크린샷 2024-01-18 오후 3 42 50" src="https://github.com/APP-iOS3rd/PJ3T3_Postie/assets/106911494/f93c4261-a8a8-4d4d-ac8e-843184bb43fb">|
|비밀번호 검증 성공||<img width="216" alt="스크린샷 2024-01-18 오후 3 42 56" src="https://github.com/APP-iOS3rd/PJ3T3_Postie/assets/106911494/6e793c51-e027-4232-8e7c-faad837b69cb">|

<!-- 질문, 중점적으로 확인받고 싶은 내용 또는 주의사항 등 자유로운 전달사항 적어주세요. -->
## 전달사항
- 회원 탈퇴 기능은 추후 구현 예정입니다.