### PR TITLE
Firestore의 편지 데이터를 수정하거나 삭제할 수 있다.

### DIFF
--- a/PJ3T3_Postie/Core/Home/ViewModel/FirestoreManager.swift
+++ b/PJ3T3_Postie/Core/Home/ViewModel/FirestoreManager.swift
@@ -49,7 +49,15 @@ class FirestoreManager: ObservableObject {
         }
     }
     
-    //기본적인 데이터 수정 함수
+    /// 데이터의 위치와 수정 후 데이터를 받아 firestore에 업데이트 한다.
+    /// - Parameters:
+    ///   - documentId: letter 구조체 안에 저장된 id를 가져옴
+    ///   - writer: 변경 된 보낸 사람
+    ///   - recipient: 변경 된 받는 사람
+    ///   - summary: 변경 된 한 줄 요약
+    ///   - date: 편지를 보내거나 받은 날짜
+    ///   - imageUrlStrings: 이미지 Url String
+    ///   - text: 변경 된 편지 본문
     func editLetter(documentId: String, writer: String, recipient: String, summary: String, date: Date, imageUrlStrings: [String], text: String) {
         let docRef = colRef.document(userUid).collection("letters").document(documentId)
         

--- a/PJ3T3_Postie/Core/Home/ViewModel/FirestoreManager.swift
+++ b/PJ3T3_Postie/Core/Home/ViewModel/FirestoreManager.swift
@@ -49,6 +49,44 @@ class FirestoreManager: ObservableObject {
         }
     }
     
+    //기본적인 데이터 수정 함수
+    func editLetter(documentId: String, writer: String, recipient: String, summary: String, date: Date, imageUrlStrings: [String], text: String) {
+        let docRef = colRef.document(userUid).collection("letters").document(documentId)
+        
+        let docData: [String: Any] = [
+            "id": documentId,
+            "writer": writer,
+            "recipient": recipient,
+            "summary": summary,
+            "date": date,
+            "imageUrlStrings": imageUrlStrings,
+            "text": text
+        ]
+        
+        docRef.updateData(docData) { error in
+            if let error = error {
+                print("Error writing document: ", error)
+            } else {
+                print("\(documentId) merge success")
+                print(docData)
+            }
+        }
+    }
+    
+    //데이터 삭제
+    //Storage의 이미지도 같이 삭제하도록 설정해야 한다.
+    func deleteRestaurant(documentId: String) {
+        let docRef = colRef.document(userUid).collection("letters").document(documentId)
+        
+        docRef.delete() { error in
+            if let error = error {
+                print("Error writing document: ", error)
+            } else {
+                print("\(documentId) delete success")
+            }
+        }
+    }
+    
     //데이터 전체를 가지고 온다.
     func fetchAllLetters() {
         let docRef = colRef.document(userUid).collection("letters") //특정 user의 document의 letters라는 하위 컬렉션 가져옴

--- a/PJ3T3_Postie/Core/Home/ViewModel/FirestoreManager.swift
+++ b/PJ3T3_Postie/Core/Home/ViewModel/FirestoreManager.swift
@@ -39,7 +39,7 @@ class FirestoreManager: ObservableObject {
             "text": text
         ]
 
-        //생성한 데이터를 해당되는 경로에 새롭게 생성한다. 이때 overwrite 하지 않는다.
+        //생성한 데이터를 해당되는 경로에 새롭게 생성한다. merge false: overwrite a document or create it if it doesn't exist yet
         document.setData(docData, merge: false) { error in
             if let error = error {
                 print(error)

--- a/PJ3T3_Postie/Core/Setting/View/SettingView.swift
+++ b/PJ3T3_Postie/Core/Setting/View/SettingView.swift
@@ -38,9 +38,9 @@ struct SettingView: View {
                                 Text(user.email)
                                     .font(.footnote)
                                     .foregroundStyle(profileBackgroundColor)
-                            } //VStack
-                        } //HStack
-                    } //Section
+                            }
+                        }
+                    }
                     
                     Section("General") {
                         HStack {
@@ -52,7 +52,7 @@ struct SettingView: View {
                                 .font(.subheadline)
                                 .foregroundStyle(profileBackgroundColor)
                         }
-                    } //Section
+                    }
                     
                     Section("Account") {
                         Button {
@@ -66,18 +66,18 @@ struct SettingView: View {
                         } label: {
                             SettingsRowView(imageName: "xmark.circle.fill", title: "Delete Account", tintColor: signOutIconColor)
                         }
-                    } //Section
+                    }
                     
                     AddDataSectionView()
                     
                     LetterDataListView()
                     
-                } //List
+                }
                 .navigationTitle("Setting")
             } else {
                 ProgressView() //로그인 중
-            } //if...else
-        } //NavigationStack
+            }
+        }
     }
 }
 
@@ -170,7 +170,7 @@ struct LetterDataListView: View {
                                 Text("To: \(letter.recipient)")
                                 
                                 Spacer()
-                            } //HStack
+                            }
                             
                             Text("\(letter.summary)")
                             
@@ -178,17 +178,17 @@ struct LetterDataListView: View {
                                 Spacer()
                                 
                                 Text("From: \(letter.writer)")
-                            } //HStack
-                        } //VStack
-                    } //NavigationLink
-                } //if
+                            }
+                        }
+                    }
+                }
             } else {
                 VStack {
                     HStack {
                         Text("To: \(letter.recipient)")
                         
                         Spacer()
-                    } //HStack
+                    }
                     
                     Text("\(letter.summary)")
                     
@@ -196,10 +196,10 @@ struct LetterDataListView: View {
                         Spacer()
                         
                         Text("From: \(letter.writer)")
-                    } //HStack
-                } //VStack
-            } //if...else
-        } //ForEach
+                    }
+                }
+            }
+        } 
     }
 }
 

--- a/PJ3T3_Postie/Core/Setting/View/SettingView.swift
+++ b/PJ3T3_Postie/Core/Setting/View/SettingView.swift
@@ -144,11 +144,11 @@ struct AddDataSectionView: View {
             
             //firestore에 document를 저장한다.
             firestoreManager.addLetter(writer: "me",
-                                             recipient: "you",
-                                             summary: "ImagesTest",
-                                             date: Date(),
-                                             imageUrlStrings: selectedImageUrls,
-                                             text: "ㅜㅜ..")
+                                       recipient: "you",
+                                       summary: "ImagesTest",
+                                       date: Date(),
+                                       imageUrlStrings: selectedImageUrls,
+                                       text: "ㅜㅜ..")
             firestoreManager.fetchAllLetters() //변경사항을 fetch한다.
         }
     }

--- a/PJ3T3_Postie/Core/Setting/View/SettingView.swift
+++ b/PJ3T3_Postie/Core/Setting/View/SettingView.swift
@@ -265,6 +265,7 @@ struct ImageAsyncView: View {
                             .resizable()
                             .frame(width: 150, height: 150)
                             .scaledToFit()
+                            .padding(10)
                     } placeholder: {
                         ProgressView()
                     }

--- a/PJ3T3_Postie/Core/Setting/View/SettingView.swift
+++ b/PJ3T3_Postie/Core/Setting/View/SettingView.swift
@@ -230,7 +230,13 @@ struct TestDetailView: View {
             
             HStack {
                 Button {
-                    //업데이트 함수 호출
+                    firestoreManager.editLetter(documentId: letter.id, 
+                                                writer: writer,
+                                                recipient: recipient,
+                                                summary: summary,
+                                                date: Date(),
+                                                imageUrlStrings: letter.imageUrlStrings ?? [],
+                                                text: text)
                     firestoreManager.fetchAllLetters()
                     dismiss()
                 } label: {
@@ -239,7 +245,7 @@ struct TestDetailView: View {
                 .buttonStyle(.borderedProminent)
                 
                 Button {
-                    //삭제 함수 호출
+                    firestoreManager.deleteRestaurant(documentId: letter.id)
                     firestoreManager.fetchAllLetters()
                     dismiss()
                 } label: {

--- a/PJ3T3_Postie/Core/Setting/View/SettingView.swift
+++ b/PJ3T3_Postie/Core/Setting/View/SettingView.swift
@@ -160,29 +160,9 @@ struct LetterDataListView: View {
     
     var body: some View {
         ForEach(firestoreManager.letters, id: \.self) { letter in
-            if let imageUrlStrings = letter.imageUrlStrings {
-                if !imageUrlStrings.isEmpty {
-                    NavigationLink {
-                        ImageAsyncView(imageUrlString: imageUrlStrings)
-                    } label: {
-                        VStack {
-                            HStack {
-                                Text("To: \(letter.recipient)")
-                                
-                                Spacer()
-                            }
-                            
-                            Text("\(letter.summary)")
-                            
-                            HStack {
-                                Spacer()
-                                
-                                Text("From: \(letter.writer)")
-                            }
-                        }
-                    }
-                }
-            } else {
+            NavigationLink {
+                TestDetailView(letter: letter)
+            } label: {
                 VStack {
                     HStack {
                         Text("To: \(letter.recipient)")
@@ -199,7 +179,75 @@ struct LetterDataListView: View {
                     }
                 }
             }
-        } 
+        }
+    }
+}
+
+struct TestDetailView: View {
+    @ObservedObject var firestoreManager = FirestoreManager.shared
+    @Environment(\.dismiss) var dismiss
+    var letter: Letter
+    @State var writer = ""
+    @State var recipient = ""
+    @State var summary = ""
+    @State var text = ""
+    
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading) {
+                Text("보낸 사람")
+                
+                TextField("\(letter.writer)", text: $writer)
+                    .textFieldStyle(.roundedBorder)
+                
+                Text("받는 사람")
+                
+                TextField("\(letter.recipient)", text: $recipient)
+                    .textFieldStyle(.roundedBorder)
+                
+                Text("한 줄 요약")
+                
+                TextField("\(letter.summary)", text: $summary)
+                    .textFieldStyle(.roundedBorder)
+                
+                Text("내용")
+                
+                TextField("\(letter.text)", text: $text)
+                    .textFieldStyle(.roundedBorder)
+                
+                if let imageUrlStrings = letter.imageUrlStrings {
+                    if !imageUrlStrings.isEmpty {
+                        ImageAsyncView(imageUrlString: imageUrlStrings)
+                    }
+                }
+            }
+            .onAppear {
+                writer = letter.writer
+                recipient = letter.recipient
+                summary = letter.summary
+                text = letter.text
+            }
+            
+            HStack {
+                Button {
+                    //업데이트 함수 호출
+                    firestoreManager.fetchAllLetters()
+                    dismiss()
+                } label: {
+                    Text("수정 완료")
+                }
+                .buttonStyle(.borderedProminent)
+                
+                Button {
+                    //삭제 함수 호출
+                    firestoreManager.fetchAllLetters()
+                    dismiss()
+                } label: {
+                    Text("삭제")
+                }
+                .buttonStyle(.borderedProminent)
+            }
+        }
     }
 }
 

--- a/PJ3T3_Postie/Core/Setting/View/SettingView.swift
+++ b/PJ3T3_Postie/Core/Setting/View/SettingView.swift
@@ -156,7 +156,7 @@ struct AddDataSectionView: View {
 
 //Firestore에 저장된 데이터를 리스트로 보여주는 뷰: 기능 테스트 후 삭제 예정
 struct LetterDataListView: View {
-    @ObservedObject var firestoreManager = FirestoreManager.shared //테스트용으로 vm 임시 선언, 삭제 예정
+    @ObservedObject var firestoreManager = FirestoreManager.shared
     
     var body: some View {
         ForEach(firestoreManager.letters, id: \.self) { letter in


### PR DESCRIPTION
<!-- 작업 동기에는 해당 작업을 수행한 이유 또는 목적을 간단히 적어주세요. -->
<!-- in progress는 진행중인 연관 이슈, close에는 닫고싶은 issue를 적습니다. -->
## 개요
- in progress
- close #43 
- 작업 요약: 앱에서 편지 데이터를 수정하거나 삭제하면 Firestore에 내용이 반영된다.

<!-- PR의 핵심이 되는 작업 내용을 적어주세요. -->
## 변경 사항
- 기존 SettigView에서 Data 리스트가 보여질 때 imageUrlStrings에 값이 있어야지만 DetailView로 navigate 될 수 있었는데, 모든 데이터에 대해 navigate되도록 수정했다.
- 리스트의 항목을 선택해 navigate된 뷰 안에서 내용을 수정하고 삭제할 수 있다.
- FirestoreManager 내부에 데이터를 수정하고 삭제하는 함수를 추가했다.

<!-- 노션 팀 페이지에 정리한 글의 링크나 참고한 블로그의 링크를 남겨주세요. -->
## 공유사항(배운 것, 참고하면 좋을 것)
- 기본적으로 수업시간에 사용했던 강사님 코드를 참고했습니다.
- https://stackoverflow.com/questions/46597327/difference-between-firestore-set-with-merge-true-and-update

<!-- 이미지 가로 크기 216 고정 -->
## 스크린샷
|제목|작업 전|작업 후||
|:-:|:-:|:-:|:-:|
|편지 리스트|<img width="216" alt="스크린샷 2024-01-23 오후 10 10 35" src="https://github.com/APP-iOS3rd/PJ3T3_Postie/assets/106911494/e0999d8d-e8d2-4a06-8037-4d4cec33516f">|<img width="216" alt="스크린샷 2024-01-26 오후 3 38 21" src="https://github.com/APP-iOS3rd/PJ3T3_Postie/assets/106911494/35b3a1f0-7d47-40f4-9540-0496d78891dc">|
|디테일뷰|없음|<img width="216" alt="스크린샷 2024-01-26 오후 3 39 14" src="https://github.com/APP-iOS3rd/PJ3T3_Postie/assets/106911494/e44308ab-953c-43cd-96a0-fa36312a565d">|<img width="216" alt="스크린샷 2024-01-26 오후 3 39 21" src="https://github.com/APP-iOS3rd/PJ3T3_Postie/assets/106911494/818f4321-5ea8-4d7e-ab13-a54e03b9284a">|

<!-- 질문, 중점적으로 확인받고 싶은 내용 또는 주의사항 등 자유로운 전달사항 적어주세요. -->
## 전달사항
- SettingView파일에 186행 TestDetailView에서 onAppear로 @State 변수에 구조체의 값 받아서 할당하는데 말고 get set을 활용하는 방법을 아실까요?
