### PR TITLE
Firestore에서 공지를 fetch할 수 있다

### DIFF
--- a/PJ3T3_Postie.xcodeproj/project.pbxproj
+++ b/PJ3T3_Postie.xcodeproj/project.pbxproj
@@ -32,6 +32,8 @@
 		9E7E05792B7C465D00ACF177 /* ClearBackground.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E7E05782B7C465D00ACF177 /* ClearBackground.swift */; };
 		9E7E057B2B7CC37800ACF177 /* AuthCaseHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E7E057A2B7CC37800ACF177 /* AuthCaseHelper.swift */; };
 		9E7E05B52B7DE54200ACF177 /* FirestoreShopManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E7E05B42B7DE54200ACF177 /* FirestoreShopManager.swift */; };
+		9E7E05B92B7DE6D200ACF177 /* FirestoreNoticeManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E7E05B82B7DE6D200ACF177 /* FirestoreNoticeManager.swift */; };
+		9E7E05BB2B7DE96500ACF177 /* OfficialLetter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E7E05BA2B7DE96500ACF177 /* OfficialLetter.swift */; };
 		9E7F8C782B5E69B000F1A6BF /* StorageManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E7F8C772B5E69B000F1A6BF /* StorageManager.swift */; };
 		9E93042D2B745DF1000B7F75 /* Shop.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E93042C2B745DF1000B7F75 /* Shop.swift */; };
 		9E93042F2B74A4B5000B7F75 /* View.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E93042E2B74A4B5000B7F75 /* View.swift */; };
@@ -136,6 +138,8 @@
 		9E7E05782B7C465D00ACF177 /* ClearBackground.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClearBackground.swift; sourceTree = "<group>"; };
 		9E7E057A2B7CC37800ACF177 /* AuthCaseHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthCaseHelper.swift; sourceTree = "<group>"; };
 		9E7E05B42B7DE54200ACF177 /* FirestoreShopManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirestoreShopManager.swift; sourceTree = "<group>"; };
+		9E7E05B82B7DE6D200ACF177 /* FirestoreNoticeManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirestoreNoticeManager.swift; sourceTree = "<group>"; };
+		9E7E05BA2B7DE96500ACF177 /* OfficialLetter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfficialLetter.swift; sourceTree = "<group>"; };
 		9E7F8C772B5E69B000F1A6BF /* StorageManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageManager.swift; sourceTree = "<group>"; };
 		9E93042C2B745DF1000B7F75 /* Shop.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Shop.swift; sourceTree = "<group>"; };
 		9E93042E2B74A4B5000B7F75 /* View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = View.swift; sourceTree = "<group>"; };
@@ -283,6 +287,7 @@
 				9E9A8BEE2B6B81050072CB75 /* GoogleUser.swift */,
 				9E9F6ADB2B57643F003DFE83 /* Letter.swift */,
 				9EA106762B63C5C90033E7A8 /* LetterPhoto.swift */,
+				9E7E05BA2B7DE96500ACF177 /* OfficialLetter.swift */,
 				9E9A8BF02B6B85640072CB75 /* PostieUser.swift */,
 				9E93042C2B745DF1000B7F75 /* Shop.swift */,
 			);
@@ -498,6 +503,7 @@
 				9E25C2D02B7B8F8A00B04BA1 /* CryptoUtils.swift */,
 				9E9F6AD72B57642D003DFE83 /* FirestoreManager.swift */,
 				9E7E05B42B7DE54200ACF177 /* FirestoreShopManager.swift */,
+				9E7E05B82B7DE6D200ACF177 /* FirestoreNoticeManager.swift */,
 				9E9A8BE82B6B704E0072CB75 /* GoogleSignInHelper.swift */,
 				9E7F8C772B5E69B000F1A6BF /* StorageManager.swift */,
 			);
@@ -753,6 +759,7 @@
 				9E9F6ADF2B5765DE003DFE83 /* Color.swift in Sources */,
 				0E29F0D82B5FA2FC005B86FB /* Button.swift in Sources */,
 				9E9F6ABA2B5762FC003DFE83 /* MapView.swift in Sources */,
+				9E7E05B92B7DE6D200ACF177 /* FirestoreNoticeManager.swift in Sources */,
 				9E9F6ACC2B5763C3003DFE83 /* RegistrationView.swift in Sources */,
 				9E9F6ABC2B576351003DFE83 /* MapCoordinator.swift in Sources */,
 				9E7E05792B7C465D00ACF177 /* ClearBackground.swift in Sources */,
@@ -791,6 +798,7 @@
 				9E9F6AC02B576368003DFE83 /* ShopView.swift in Sources */,
 				E39C35F12B71F820001F6E5F /* ContenViewModel.swift in Sources */,
 				9E9F6ACA2B5763B8003DFE83 /* LoginView.swift in Sources */,
+				9E7E05BB2B7DE96500ACF177 /* OfficialLetter.swift in Sources */,
 				E349F8882B6B673C00253B02 /* GroupedLetterView.swift in Sources */,
 				9E25C2CD2B7B454000B04BA1 /* EnvironmentValues.swift in Sources */,
 				9E46837C2B7BBBA100EFB90B /* LoadingView.swift in Sources */,

--- a/PJ3T3_Postie.xcodeproj/project.pbxproj
+++ b/PJ3T3_Postie.xcodeproj/project.pbxproj
@@ -502,8 +502,8 @@
 				9E9F6ACD2B5763CA003DFE83 /* AuthManager.swift */,
 				9E25C2D02B7B8F8A00B04BA1 /* CryptoUtils.swift */,
 				9E9F6AD72B57642D003DFE83 /* FirestoreManager.swift */,
-				9E7E05B42B7DE54200ACF177 /* FirestoreShopManager.swift */,
 				9E7E05B82B7DE6D200ACF177 /* FirestoreNoticeManager.swift */,
+				9E7E05B42B7DE54200ACF177 /* FirestoreShopManager.swift */,
 				9E9A8BE82B6B704E0072CB75 /* GoogleSignInHelper.swift */,
 				9E7F8C772B5E69B000F1A6BF /* StorageManager.swift */,
 			);

--- a/PJ3T3_Postie.xcodeproj/project.pbxproj
+++ b/PJ3T3_Postie.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		9E5889E32B72221B00B4AD20 /* SearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E5889E22B72221B00B4AD20 /* SearchView.swift */; };
 		9E7E05792B7C465D00ACF177 /* ClearBackground.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E7E05782B7C465D00ACF177 /* ClearBackground.swift */; };
 		9E7E057B2B7CC37800ACF177 /* AuthCaseHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E7E057A2B7CC37800ACF177 /* AuthCaseHelper.swift */; };
+		9E7E05B52B7DE54200ACF177 /* FirestoreShopManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E7E05B42B7DE54200ACF177 /* FirestoreShopManager.swift */; };
 		9E7F8C782B5E69B000F1A6BF /* StorageManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E7F8C772B5E69B000F1A6BF /* StorageManager.swift */; };
 		9E93042D2B745DF1000B7F75 /* Shop.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E93042C2B745DF1000B7F75 /* Shop.swift */; };
 		9E93042F2B74A4B5000B7F75 /* View.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E93042E2B74A4B5000B7F75 /* View.swift */; };
@@ -134,6 +135,7 @@
 		9E5889E22B72221B00B4AD20 /* SearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchView.swift; sourceTree = "<group>"; };
 		9E7E05782B7C465D00ACF177 /* ClearBackground.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClearBackground.swift; sourceTree = "<group>"; };
 		9E7E057A2B7CC37800ACF177 /* AuthCaseHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthCaseHelper.swift; sourceTree = "<group>"; };
+		9E7E05B42B7DE54200ACF177 /* FirestoreShopManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirestoreShopManager.swift; sourceTree = "<group>"; };
 		9E7F8C772B5E69B000F1A6BF /* StorageManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageManager.swift; sourceTree = "<group>"; };
 		9E93042C2B745DF1000B7F75 /* Shop.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Shop.swift; sourceTree = "<group>"; };
 		9E93042E2B74A4B5000B7F75 /* View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = View.swift; sourceTree = "<group>"; };
@@ -495,6 +497,7 @@
 				9E9F6ACD2B5763CA003DFE83 /* AuthManager.swift */,
 				9E25C2D02B7B8F8A00B04BA1 /* CryptoUtils.swift */,
 				9E9F6AD72B57642D003DFE83 /* FirestoreManager.swift */,
+				9E7E05B42B7DE54200ACF177 /* FirestoreShopManager.swift */,
 				9E9A8BE82B6B704E0072CB75 /* GoogleSignInHelper.swift */,
 				9E7F8C772B5E69B000F1A6BF /* StorageManager.swift */,
 			);
@@ -768,6 +771,7 @@
 				9E9F6AC22B576393003DFE83 /* MapApi.swift in Sources */,
 				9E93042D2B745DF1000B7F75 /* Shop.swift in Sources */,
 				9E25C2D12B7B8F8A00B04BA1 /* CryptoUtils.swift in Sources */,
+				9E7E05B52B7DE54200ACF177 /* FirestoreShopManager.swift in Sources */,
 				0E882AF02B6B79D800D8F2FC /* CoordinaterEtc.swift in Sources */,
 				0E882AEE2B6B73DE00D8F2FC /* LocationManager.swift in Sources */,
 				9E9F6AD42B576411003DFE83 /* LetterDetailView.swift in Sources */,

--- a/PJ3T3_Postie/Core/Setting/View/SettingView.swift
+++ b/PJ3T3_Postie/Core/Setting/View/SettingView.swift
@@ -389,13 +389,13 @@ struct NoticeTestView: View {
     var body: some View {
         VStack {            
             Section {
-                ForEach(firestoreNoticeManager.notice, id:\.self) { notice in
+                ForEach(firestoreNoticeManager.notices, id:\.self) { notice in
                     Text(notice.title)
                 }
             }
         }
         .onAppear {
-            if firestoreNoticeManager.notice.isEmpty {
+            if firestoreNoticeManager.notices.isEmpty {
                 firestoreNoticeManager.fetchAllNotices()
             }
         }

--- a/PJ3T3_Postie/Core/Setting/View/SettingView.swift
+++ b/PJ3T3_Postie/Core/Setting/View/SettingView.swift
@@ -395,7 +395,9 @@ struct NoticeTestView: View {
             }
         }
         .onAppear {
-            firestoreNoticeManager.fetchAllNotices()
+            if firestoreNoticeManager.notice.isEmpty {
+                firestoreNoticeManager.fetchAllNotices()
+            }
         }
     }
 }

--- a/PJ3T3_Postie/Core/Setting/View/SettingView.swift
+++ b/PJ3T3_Postie/Core/Setting/View/SettingView.swift
@@ -124,6 +124,8 @@ struct SettingView: View {
                         }
                     }
                     
+                    NoticeTestView()
+                    
                     AddDataSectionView()
                     
                     LetterDataListView()
@@ -362,10 +364,10 @@ struct TestImageView: View {
 }
 
 struct ShopListView: View {
-    @ObservedObject var firestoreManager = FirestoreManager.shared
+    @ObservedObject var firestoreShopManager = FirestoreShopManager.shared
     
     var body: some View {
-        ForEach(firestoreManager.shops, id: \.self) { shop in
+        ForEach(firestoreShopManager.shops, id: \.self) { shop in
             HStack {
                 Text(shop.title)
                 
@@ -377,6 +379,23 @@ struct ShopListView: View {
                     ProgressView()
                 }
             }
+        }
+    }
+}
+
+struct NoticeTestView: View {
+    @ObservedObject var firestoreNoticeManager = FirestoreNoticeManager.shared
+    
+    var body: some View {
+        VStack {            
+            Section {
+                ForEach(firestoreNoticeManager.notice, id:\.self) { notice in
+                    Text(notice.title)
+                }
+            }
+        }
+        .onAppear {
+            firestoreNoticeManager.fetchAllNotices()
         }
     }
 }

--- a/PJ3T3_Postie/Manager/FirestoreManager.swift
+++ b/PJ3T3_Postie/Manager/FirestoreManager.swift
@@ -12,12 +12,10 @@ class FirestoreManager: ObservableObject {
     var letterColRef: CollectionReference = Firestore.firestore().collection("users")
     var docId: String = ""
     @Published var letters: [Letter] = []
-    @Published var shops: [Shop] = []
     @Published var letter: Letter = Letter(id: "", writer: "", recipient: "", summary: "", date: Date(), text: "", isReceived: false, isFavorite: false)
 
     private init() { 
         fetchReference()
-        fetchAllShops()
     }
     
     func fetchReference() {
@@ -174,36 +172,6 @@ class FirestoreManager: ObservableObject {
             }
             
             print("Letter fetch success")
-        }
-    }
-    
-    func fetchAllShops() {
-        let docRef = Firestore.firestore().collection("shops")
-        
-        docRef.getDocuments { snapshot, error in
-            guard error == nil else {
-                print(error?.localizedDescription ?? "Undefined error")
-                return
-            }
-            
-            self.shops.removeAll()
-            
-            guard let snapshot = snapshot else {
-                print("\(#function): No snapshot \(String(describing: error?.localizedDescription))")
-                return
-            }
-            
-            for document in snapshot.documents {
-                do {
-                    let data = try document.data(as: Shop.self)
-                    
-                    self.shops.append(data)
-                } catch {
-                    print(#function, error.localizedDescription)
-                }
-            }
-            
-            print("Shop fetch success")
         }
     }
 }

--- a/PJ3T3_Postie/Manager/FirestoreNoticeManager.swift
+++ b/PJ3T3_Postie/Manager/FirestoreNoticeManager.swift
@@ -1,0 +1,45 @@
+//
+//  FirestoreOLManager.swift
+//  PJ3T3_Postie
+//
+//  Created by Eunsu JEONG on 2/15/24.
+//
+
+import FirebaseFirestore
+
+final class FirestoreNoticeManager: ObservableObject {
+    static let shared = FirestoreNoticeManager()
+    @Published var notice: [Shop] = []
+    
+    private init() { }
+    
+    func fetchAllShops() {
+        let docRef = Firestore.firestore().collection("shops")
+        
+        docRef.getDocuments { snapshot, error in
+            guard error == nil else {
+                print(error?.localizedDescription ?? "Undefined error")
+                return
+            }
+            
+            self.shops.removeAll()
+            
+            guard let snapshot = snapshot else {
+                print("\(#function): No snapshot \(String(describing: error?.localizedDescription))")
+                return
+            }
+            
+            for document in snapshot.documents {
+                do {
+                    let data = try document.data(as: Shop.self)
+                    
+                    self.shops.append(data)
+                } catch {
+                    print(#function, error.localizedDescription)
+                }
+            }
+            
+            print("Shop fetch success")
+        }
+    }
+}

--- a/PJ3T3_Postie/Manager/FirestoreNoticeManager.swift
+++ b/PJ3T3_Postie/Manager/FirestoreNoticeManager.swift
@@ -1,5 +1,5 @@
 //
-//  FirestoreOLManager.swift
+//  FirestoreNoticeManager.swift
 //  PJ3T3_Postie
 //
 //  Created by Eunsu JEONG on 2/15/24.
@@ -9,12 +9,13 @@ import FirebaseFirestore
 
 final class FirestoreNoticeManager: ObservableObject {
     static let shared = FirestoreNoticeManager()
-    @Published var notice: [Shop] = []
+    @Published var notice: [OfficialLetter] = []
+    @Published var faq: [OfficialLetter] = []
     
     private init() { }
     
-    func fetchAllShops() {
-        let docRef = Firestore.firestore().collection("shops")
+    func fetchAllNotices() {
+        let docRef = Firestore.firestore().collection("notice")
         
         docRef.getDocuments { snapshot, error in
             guard error == nil else {
@@ -22,7 +23,7 @@ final class FirestoreNoticeManager: ObservableObject {
                 return
             }
             
-            self.shops.removeAll()
+            self.notice.removeAll()
             
             guard let snapshot = snapshot else {
                 print("\(#function): No snapshot \(String(describing: error?.localizedDescription))")
@@ -31,15 +32,15 @@ final class FirestoreNoticeManager: ObservableObject {
             
             for document in snapshot.documents {
                 do {
-                    let data = try document.data(as: Shop.self)
+                    let data = try document.data(as: OfficialLetter.self)
                     
-                    self.shops.append(data)
+                    self.notice.append(data)
                 } catch {
                     print(#function, error.localizedDescription)
                 }
             }
             
-            print("Shop fetch success")
+            print("Notice fetch success")
         }
     }
 }

--- a/PJ3T3_Postie/Manager/FirestoreNoticeManager.swift
+++ b/PJ3T3_Postie/Manager/FirestoreNoticeManager.swift
@@ -9,8 +9,8 @@ import FirebaseFirestore
 
 final class FirestoreNoticeManager: ObservableObject {
     static let shared = FirestoreNoticeManager()
-    @Published var notice: [OfficialLetter] = []
-    @Published var faq: [OfficialLetter] = []
+    @Published var notices: [OfficialLetter] = []
+    @Published var faqs: [OfficialLetter] = []
     
     private init() { }
     
@@ -23,7 +23,7 @@ final class FirestoreNoticeManager: ObservableObject {
                 return
             }
             
-            self.notice.removeAll()
+            self.notices.removeAll()
             
             guard let snapshot = snapshot else {
                 print("\(#function): No snapshot \(String(describing: error?.localizedDescription))")
@@ -34,7 +34,7 @@ final class FirestoreNoticeManager: ObservableObject {
                 do {
                     let data = try document.data(as: OfficialLetter.self)
                     
-                    self.notice.append(data)
+                    self.notices.append(data)
                 } catch {
                     print(#function, error.localizedDescription)
                 }

--- a/PJ3T3_Postie/Manager/FirestoreShopManager.swift
+++ b/PJ3T3_Postie/Manager/FirestoreShopManager.swift
@@ -1,0 +1,47 @@
+//
+//  FirestoreShopManager.swift
+//  PJ3T3_Postie
+//
+//  Created by Eunsu JEONG on 2/15/24.
+//
+
+import FirebaseFirestore
+
+final class FirestoreShopManager: ObservableObject {
+    static let shared = FirestoreShopManager()
+    @Published var shops: [Shop] = []
+    
+    private init() {
+        fetchAllShops()
+    }
+    
+    func fetchAllShops() {
+        let docRef = Firestore.firestore().collection("shops")
+        
+        docRef.getDocuments { snapshot, error in
+            guard error == nil else {
+                print(error?.localizedDescription ?? "Undefined error")
+                return
+            }
+            
+            self.shops.removeAll()
+            
+            guard let snapshot = snapshot else {
+                print("\(#function): No snapshot \(String(describing: error?.localizedDescription))")
+                return
+            }
+            
+            for document in snapshot.documents {
+                do {
+                    let data = try document.data(as: Shop.self)
+                    
+                    self.shops.append(data)
+                } catch {
+                    print(#function, error.localizedDescription)
+                }
+            }
+            
+            print("Shop fetch success")
+        }
+    }
+}

--- a/PJ3T3_Postie/Model/OfficialLetter.swift
+++ b/PJ3T3_Postie/Model/OfficialLetter.swift
@@ -1,0 +1,8 @@
+//
+//  OfficialLetter.swift
+//  PJ3T3_Postie
+//
+//  Created by Eunsu JEONG on 2/15/24.
+//
+
+import Foundation

--- a/PJ3T3_Postie/Model/OfficialLetter.swift
+++ b/PJ3T3_Postie/Model/OfficialLetter.swift
@@ -6,3 +6,9 @@
 //
 
 import Foundation
+
+struct OfficialLetter: Identifiable, Hashable, Codable {
+    let id: String
+    let title: String
+    let content: String
+}


### PR DESCRIPTION
<!-- 작업 동기에는 해당 작업을 수행한 이유 또는 목적을 간단히 적어주세요. -->
<!-- in progress는 진행중인 연관 이슈, close에는 닫고싶은 issue를 적습니다. -->
## 개요
- in progress
- close #120 
- 작업 요약
  - Firestore에서 공지를 fetch하는 manager와 코드 추가
  - 기존 FirestoreManager에서 fetch하던 shop을 별도의 파일로 분리

<!-- PR의 핵심이 되는 작업 내용을 적어주세요. -->
## 변경 사항
- Firestore에서 공지를 fetch하는 manager와 코드 추가
  - 공지는 title과 content, id, 날짜를 가지며 id는 가능한 firestore에서 자동 생성해주는 uuid를 사용
  - firestore에서 직접 데이터 추가 해 사용
  - 뷰의 onAppear로 fetch
    - 단 공지가 매번 뷰를 띄울 때 마다 fetch되지 않고 공지 배열이 비어있을 때만 fetch하도록 if로 검증
  - SettingView 최하단의 코드 NoticeTestView 참고
- 기존 FirestoreManager에서 fetch하던 shop을 별도의 파일로 분리

<!-- 노션 팀 페이지에 정리한 글의 링크나 참고한 블로그의 링크를 남겨주세요. -->
## 공유사항(배운 것, 참고하면 좋을 것)
- 

<!-- 이미지 가로 크기 216 고정 -->
## 스크린샷
|제목|작업 전|작업 후|
|:-:|:-:|:-:| 
|테스트 공지 section 추가|<img width="216" src="https://github.com/APP-iOS3rd/PJ3T3_Postie/assets/106911494/e88955ae-73fc-4693-ad20-59a591791c13">|<img width="216" src="https://github.com/APP-iOS3rd/PJ3T3_Postie/assets/106911494/bc7b9dcb-30af-4dff-901e-016ea6a3aa57">|

<!-- 질문, 중점적으로 확인받고 싶은 내용 또는 주의사항 등 자유로운 전달사항 적어주세요. -->
## 전달사항
-
