### PR TITLE
편지 저장 및 수정 로직 변경에 따른 firestore, storage 코드 재구현

### DIFF
--- a/PJ3T3_Postie.xcodeproj/project.pbxproj
+++ b/PJ3T3_Postie.xcodeproj/project.pbxproj
@@ -964,7 +964,7 @@
 				CODE_SIGN_ENTITLEMENTS = PJ3T3_Postie/PJ3T3_Postie.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 3;
+				CURRENT_PROJECT_VERSION = 4;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_ASSET_PATHS = "\"PJ3T3_Postie/Preview Content\"";
 				DEVELOPMENT_TEAM = Y6QXM3Q994;
@@ -984,7 +984,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.2;
+				MARKETING_VERSION = 1.0.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jes.e.0927.PJ3T3Postie;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1007,7 +1007,7 @@
 				CODE_SIGN_ENTITLEMENTS = PJ3T3_Postie/PJ3T3_Postie.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 3;
+				CURRENT_PROJECT_VERSION = 4;
 				DEVELOPMENT_ASSET_PATHS = "\"PJ3T3_Postie/Preview Content\"";
 				DEVELOPMENT_TEAM = Y6QXM3Q994;
 				ENABLE_PREVIEWS = YES;
@@ -1025,7 +1025,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.2;
+				MARKETING_VERSION = 1.0.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jes.e.0927.PJ3T3Postie;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/PJ3T3_Postie/Core/Setting/View/SettingView.swift
+++ b/PJ3T3_Postie/Core/Setting/View/SettingView.swift
@@ -291,6 +291,7 @@ struct TestDetailView: View {
                 
                 Button {
                     firestoreManager.deleteLetter(documentId: letter.id)
+                    storageManager.deleteFolder(docId: letter.id)
                     firestoreManager.fetchAllLetters()
                     dismiss()
                 } label: {

--- a/PJ3T3_Postie/Core/Setting/View/SettingView.swift
+++ b/PJ3T3_Postie/Core/Setting/View/SettingView.swift
@@ -262,8 +262,36 @@ struct TestDetailView: View {
                 TextField("\(letter.text)", text: $text)
                     .textFieldStyle(.roundedBorder)
                 
-                if !storageManager.images.isEmpty {
-                    TestImageView(images: storageManager.images)
+                if !currentFullPathAndURLs.isEmpty {
+                    ScrollView(.horizontal) {
+                        LazyHGrid(rows: rows) {
+                            ForEach(currentFullPathAndURLs, id: \.self) { item in
+                                AsyncImage(url: URL(string: item[1])) { image in
+                                    ZStack(alignment: .topTrailing) {
+                                        image
+                                            .resizable()
+                                            .frame(width: 150, height: 150)
+                                            .scaledToFit()
+                                            .padding(.leading, 10)
+                                        
+                                        Button {
+                                            deleteImageFullPaths.append(item[0])
+                                            deleteImageURLs.append(item[1])
+                                            currentFullPathAndURLs.remove(at: currentFullPathAndURLs.firstIndex(of: item)!)
+                                        } label: {
+                                            Image(systemName: "xmark.circle.fill")
+                                                .foregroundStyle(.gray)
+                                                .frame(width: 20, height: 20)
+                                                .padding(5)
+                                        }
+                                    }
+                                } placeholder: {
+                                    ProgressView()
+                                        .frame(width: 150, height: 150)
+                                }
+                            }
+                        }
+                    }
                 }
             }
             

--- a/PJ3T3_Postie/Core/Setting/View/SettingView.swift
+++ b/PJ3T3_Postie/Core/Setting/View/SettingView.swift
@@ -233,11 +233,22 @@ struct TestDetailView: View {
     @ObservedObject var firestoreManager = FirestoreManager.shared
     @ObservedObject var storageManager = StorageManager.shared
     @Environment(\.dismiss) var dismiss
+    //편지 디테일
     var letter: Letter
+    let rows = Array(repeating: GridItem(.adaptive(minimum: 100)), count: 1)
     @State var writer = ""
     @State var recipient = ""
     @State var summary = ""
     @State var text = ""
+    @State var currentFullPaths = [String]()
+    @State var currentUrls = [String]()
+    @State var currentFullPathAndURLs = [[String]]()
+    //이미지 삭제
+    @State var deleteImageFullPaths = [String]()
+    @State var deleteImageURLs = [String]()
+    //새 이미지 추가
+    @State private var selectedItem: PhotosPickerItem? = nil
+    @State private var selectedImages: [UIImage] = []
     
     var body: some View {
         ScrollView {

--- a/PJ3T3_Postie/Core/Setting/View/SettingView.swift
+++ b/PJ3T3_Postie/Core/Setting/View/SettingView.swift
@@ -300,6 +300,11 @@ struct TestDetailView: View {
             summary = letter.summary
             text = letter.text
             storageManager.listAllFile(docId: letter.id)
+            writer = letter.writer
+            recipient = letter.recipient
+            summary = letter.summary
+            text = letter.text
+            storageManager.listAllFile(docId: letter.id)
         }
         .onDisappear {
             //뷰가 dismiss될 때 images 배열 초기화
@@ -338,8 +343,40 @@ struct TestImageView: View {
                     } placeholder: {
                         ProgressView()
                     }
-                }
+        .onDisappear {
+            //뷰가 dismiss될 때 images 배열 초기화
+            storageManager.images.removeAll()
+        }
+    }
+}
+
+struct TestImageView: View {
+    @ObservedObject var storageManager = StorageManager.shared
+    let rows = Array(repeating: GridItem(.adaptive(minimum: 100)), count: 1)
+    var images: [LetterPhoto]
+    
+    func initLetterDetail() {
+        writer = letter.writer
+        recipient = letter.recipient
+        summary = letter.summary
+        text = letter.text
+        
+        if let currentFullPaths = letter.imageFullPaths {
+            self.currentFullPaths = currentFullPaths
+        }
+        
+        if let currentUrls = letter.imageURLs {
+            self.currentUrls = currentUrls
+        }
+        
+        if currentUrls.count == currentFullPaths.count {
+            let imageCount = currentUrls.count
+            
+            for i in 0..<imageCount {
+                currentFullPathAndURLs.append([currentFullPaths[i], currentUrls[i]])
             }
+        } else {
+            print("현재 letter는 Image url의 개수와 fullPath의 개수가 다릅니다.")
         }
     }
 }

--- a/PJ3T3_Postie/Manager/FirestoreManager.swift
+++ b/PJ3T3_Postie/Manager/FirestoreManager.swift
@@ -10,8 +10,10 @@ import FirebaseFirestore
 class FirestoreManager: ObservableObject {
     static let shared = FirestoreManager()
     var letterColRef: CollectionReference = Firestore.firestore().collection("users")
+    @available(*, deprecated, message: "모든 뷰에서 제거 해주세요. 제거가 완료되면 이 변수를 삭제 후 커밋 해 주세요.")
     var docId: String = "" //deprecated
     @Published var letters: [Letter] = []
+    @available(*, deprecated, message: "모든 뷰에서 제거 해주세요. 제거가 완료되면 이 변수를 삭제 후 커밋 해 주세요.")
     @Published var letter: Letter = Letter(id: "", writer: "", recipient: "", summary: "", date: Date(), text: "", isReceived: false, isFavorite: false) //deprecated
 
     private init() { 

--- a/PJ3T3_Postie/Manager/FirestoreManager.swift
+++ b/PJ3T3_Postie/Manager/FirestoreManager.swift
@@ -106,6 +106,41 @@ class FirestoreManager: ObservableObject {
         }
     }
     
+    func updateLetter(docId: String, writer: String, recipient: String, summary: String, date: Date, text: String, isReceived: Bool, isFavorite: Bool, imageURLs: [String]?, imageFullPaths: [String]?) {
+        let docRef = letterColRef.document(letter.id)
+        var docData = [String: Any]()
+        
+        if let imageURLs = letter.imageURLs, let imageFullPaths = letter.imageFullPaths {
+            docData = ["id": docId,
+                       "writer": writer,
+                       "recipient": recipient,
+                       "summary": summary,
+                       "date": date,
+                       "text": text,
+                       "isReceived": isReceived,
+                       "isFavorite": isFavorite,
+                       "imageURLs": FieldValue.arrayUnion(imageURLs),
+                       "imageFullPaths": FieldValue.arrayUnion(imageFullPaths)]
+        } else {
+            docData = ["id": docId,
+                       "writer": writer,
+                       "recipient": recipient,
+                       "summary": summary,
+                       "date": date,
+                       "text": text,
+                       "isReceived": isReceived,
+                       "isFavorite": isFavorite]
+        }
+        
+        docRef.updateData(docData) { error in
+            if let error = error {
+                print("Failed to updating document: ", error)
+            } else {
+                print("\(docId) merge success")
+            }
+        }
+    }
+    
     func removeFullPathsAndURLs(docId: String, fullPaths: [String], urls: [String]) {
         let docRef = letterColRef.document(docId)
         

--- a/PJ3T3_Postie/Manager/FirestoreManager.swift
+++ b/PJ3T3_Postie/Manager/FirestoreManager.swift
@@ -24,6 +24,7 @@ class FirestoreManager: ObservableObject {
         fetchAllLetters()
     }
 
+//MARK: - 편지 추가
     func addLetter(docId: String, letter: Letter) async throws {
         try letterColRef.document(docId).setData(from: letter)
     }
@@ -72,6 +73,7 @@ class FirestoreManager: ObservableObject {
         }
     }
     
+//MARK: - 편지 수정
     /// 데이터의 위치와 수정 후 데이터를 받아 firestore에 업데이트 한다.
     /// - Parameters:
     ///   - documentId: letter 구조체 안에 저장된 id를 가져옴
@@ -103,42 +105,7 @@ class FirestoreManager: ObservableObject {
         }
     }
     
-    //데이터 삭제
-    //Storage의 이미지도 같이 삭제하도록 설정해야 한다.
-    func deleteLetter(documentId: String) {
-        let docRef = letterColRef.document(documentId)
-        
-        docRef.delete() { error in
-            if let error = error {
-                print(#function, "Error deleting document: ", error)
-            } else {
-                print(#function, "\(documentId) delete success")
-            }
-        }
-    }
-    
-    func deleteUserDocument(userUid: String) {
-        let userDocRef = Firestore.firestore().collection("users").document(userUid)
-        var letterQty = 0
-        
-        for letter in letters {
-                self.deleteLetter(documentId: letter.id)
-                StorageManager.shared.deleteFolder(docId: letter.id)
-            letterQty += 1
-        }
-        
-        print("Deleted \(letterQty)letters")
-        
-        userDocRef.delete { error in
-            if let error = error {
-                print(#function, "Error deleting document: ", error)
-            } else {
-                print(#function, "\(userUid) delete success")
-            }
-        }
-    }
-
-    //데이터 전체를 가지고 온다.
+//MARK: - 편지 fetch
     func fetchAllLetters() {
         //letterColRef(특정 user의 document의 letters라는 하위 컬렉션)에 있는 모든 document를 가져옴
         letterColRef.getDocuments { snapshot, error in
@@ -178,6 +145,42 @@ class FirestoreManager: ObservableObject {
             }
             
             print("Letter fetch success")
+        }
+    }
+
+//MARK: - 편지 삭제
+    //데이터 삭제
+    //Storage의 이미지도 같이 삭제하도록 설정해야 한다.
+    func deleteLetter(documentId: String) {
+        let docRef = letterColRef.document(documentId)
+        
+        docRef.delete() { error in
+            if let error = error {
+                print(#function, "Error deleting document: ", error)
+            } else {
+                print(#function, "\(documentId) delete success")
+            }
+        }
+    }
+    
+    func deleteUserDocument(userUid: String) {
+        let userDocRef = Firestore.firestore().collection("users").document(userUid)
+        var letterQty = 0
+        
+        for letter in letters {
+            self.deleteLetter(documentId: letter.id)
+            StorageManager.shared.deleteFolder(docId: letter.id)
+            letterQty += 1
+        }
+        
+        print("Deleted \(letterQty)letters")
+        
+        userDocRef.delete { error in
+            if let error = error {
+                print(#function, "Error deleting document: ", error)
+            } else {
+                print(#function, "\(userUid) delete success")
+            }
         }
     }
 }

--- a/PJ3T3_Postie/Manager/FirestoreManager.swift
+++ b/PJ3T3_Postie/Manager/FirestoreManager.swift
@@ -106,6 +106,19 @@ class FirestoreManager: ObservableObject {
         }
     }
     
+    func removeFullPathsAndURLs(docId: String, fullPaths: [String], urls: [String]) {
+        let docRef = letterColRef.document(docId)
+        
+        docRef.updateData(["imageURLs": FieldValue.arrayRemove(urls),
+                           "imageFullPaths": FieldValue.arrayRemove(fullPaths)]) { error in
+            if let error = error {
+                print(#function, "Failed to update fullPath and url: ", error)
+            } else {
+                print("\(docId) merge success")
+            }
+        }
+    }
+    
 //MARK: - 편지 fetch
     func fetchAllLetters() {
         //letterColRef(특정 user의 document의 letters라는 하위 컬렉션)에 있는 모든 document를 가져옴

--- a/PJ3T3_Postie/Manager/FirestoreManager.swift
+++ b/PJ3T3_Postie/Manager/FirestoreManager.swift
@@ -83,6 +83,7 @@ class FirestoreManager: ObservableObject {
     ///   - summary: 변경 된 한 줄 요약
     ///   - date: 편지를 보내거나 받은 날짜
     ///   - text: 변경 된 편지 본문
+    @available(*, deprecated, message: "이 함수는 더이상 사용하지 않습니다. updateLetter 함수를 사용 해 주세요. 뷰에서 더이상 사용하는 곳이 없다면 함수를 삭제 해 주세요.")
     func editLetter(documentId: String, writer: String, recipient: String, summary: String, date: Date, text: String, isReceived: Bool, isFavorite: Bool) {
         let docRef = letterColRef.document(documentId)
         let docData: [String: Any] = [

--- a/PJ3T3_Postie/Manager/FirestoreManager.swift
+++ b/PJ3T3_Postie/Manager/FirestoreManager.swift
@@ -10,9 +10,9 @@ import FirebaseFirestore
 class FirestoreManager: ObservableObject {
     static let shared = FirestoreManager()
     var letterColRef: CollectionReference = Firestore.firestore().collection("users")
-    var docId: String = ""
+    var docId: String = "" //deprecated
     @Published var letters: [Letter] = []
-    @Published var letter: Letter = Letter(id: "", writer: "", recipient: "", summary: "", date: Date(), text: "", isReceived: false, isFavorite: false)
+    @Published var letter: Letter = Letter(id: "", writer: "", recipient: "", summary: "", date: Date(), text: "", isReceived: false, isFavorite: false) //deprecated
 
     private init() { 
         fetchReference()
@@ -46,6 +46,7 @@ class FirestoreManager: ObservableObject {
         try letterColRef.document(docId).setData(from: letter)
     }
     
+    @available(*, deprecated, message: "모든 뷰에서 제거 해주세요. 제거가 완료되면 이 함수의 코드도 삭제 후 커밋 해 주세요.")
     func addLetter(writer: String, recipient: String, summary: String, date: Date, text: String, isReceived: Bool, isFavorite: Bool) async {
         let document = letterColRef.document() //새로운 document를 생성한다.
         let documentId = document.documentID //생성한 document의 id를 가져온다.

--- a/PJ3T3_Postie/Manager/FirestoreManager.swift
+++ b/PJ3T3_Postie/Manager/FirestoreManager.swift
@@ -150,8 +150,6 @@ class FirestoreManager: ObservableObject {
     }
 
 //MARK: - 편지 삭제
-    //데이터 삭제
-    //Storage의 이미지도 같이 삭제하도록 설정해야 한다.
     func deleteLetter(documentId: String) {
         let docRef = letterColRef.document(documentId)
         

--- a/PJ3T3_Postie/Manager/FirestoreManager.swift
+++ b/PJ3T3_Postie/Manager/FirestoreManager.swift
@@ -24,7 +24,27 @@ class FirestoreManager: ObservableObject {
         fetchAllLetters()
     }
 
-    //새로운 편지를 추가한다.
+    func addLetter(docId: String, letter: Letter) async throws {
+        try letterColRef.document(docId).setData(from: letter)
+    }
+    
+    ///이 함수를 사용할 경우 업로드 완료시 fetchAllLetters를 수행 해 주세요.
+    func addLetter(docId: String, writer: String, recipient: String, summary: String, date: Date, text: String, isReceived: Bool, isFavorite: Bool, imageURLs: [String]?, imageFullPaths: [String]?) async throws {
+        //imageURLs와 imageFullPaths 둘 중 하나만 nil인 경우를 걸러낼 수 있을까요?
+        let letter = Letter(id: docId,
+                            writer: writer,
+                            recipient: recipient,
+                            summary: summary,
+                            date: date,
+                            text: text,
+                            isReceived: isReceived,
+                            isFavorite: isFavorite,
+                            imageURLs: imageURLs,
+                            imageFullPaths: imageFullPaths)
+        
+        try letterColRef.document(docId).setData(from: letter)
+    }
+    
     func addLetter(writer: String, recipient: String, summary: String, date: Date, text: String, isReceived: Bool, isFavorite: Bool) async {
         let document = letterColRef.document() //새로운 document를 생성한다.
         let documentId = document.documentID //생성한 document의 id를 가져온다.

--- a/PJ3T3_Postie/Manager/StorageManager.swift
+++ b/PJ3T3_Postie/Manager/StorageManager.swift
@@ -24,6 +24,7 @@ final class StorageManager: ObservableObject {
         self.userReference = Storage.storage().reference().child("users").child(userUid)
     }
     
+//MARK: - 사진 업로드
     func uploadUIImage(image: UIImage, docId: String) async throws -> String {
             //metadata없이도 data를 업로드 할 수 있지만, 그 경우 서버는 어떤 타입의 데이터를 저장하는지 알지 못해 오류를 발생시킬 수 있으므로 upload하는 metadata 타입을 명시 해 주는 편이 좋다.
             let meta = StorageMetadata()
@@ -114,6 +115,7 @@ final class StorageManager: ObservableObject {
         return letterPhoto
     }
     
+//MARK: - 사진 fetch
     //Firebase의 listAll() 메서드를 사용하여 특정 경로에 포함된 모든 항목을 images 배열에 추가
     func listAllFile(docId: String) {
         //이미지 폴더의 모든 파일을 나열
@@ -143,10 +145,10 @@ final class StorageManager: ObservableObject {
                     }
                 }
             }
-            print(self.images)
         }
     }
     
+//MARK: - 사진 삭제
     func deleteItem(fullPath: String) {
         let item = Storage.storage().reference().child(fullPath)
         

--- a/PJ3T3_Postie/Manager/StorageManager.swift
+++ b/PJ3T3_Postie/Manager/StorageManager.swift
@@ -70,6 +70,7 @@ final class StorageManager: ObservableObject {
        - userId: 현재 로그인중인 유저의 uuid로 이미지를 업로드 할 경로를 생성하거나 찾는데 사용한다.
        - docId: 방금 생성한 firestore문서 id로 이미지를 업로드 할 경로를 생성하거나 찾는데 사용한다.
      */
+    @available(*, deprecated, message: "이 함수는 더이상 사용하지 않습니다. String을 return하는 uploadUIImage 함수를 사용 해 주세요. 뷰에서 더이상 사용하는 곳이 없다면 함수를 삭제 해 주세요.")
     func saveUIImage(images: [UIImage], docId: String) async throws {
         //metadata없이도 data를 업로드 할 수 있지만, 그 경우 서버는 어떤 타입의 데이터를 저장하는지 알지 못해 오류를 발생시킬 수 있으므로 upload하는 metadata 타입을 명시 해 주는 편이 좋다.
         let meta = StorageMetadata()
@@ -104,38 +105,7 @@ final class StorageManager: ObservableObject {
         print("함수를 uploadUIImage로 교체해 사용 해 주세요!")
     }
     
-    func uploadUIImage(image: UIImage, docId: String) async throws {
-        //metadata없이도 data를 업로드 할 수 있지만, 그 경우 서버는 어떤 타입의 데이터를 저장하는지 알지 못해 오류를 발생시킬 수 있으므로 upload하는 metadata 타입을 명시 해 주는 편이 좋다.
-        let meta = StorageMetadata()
-        meta.contentType = "image/jpeg"
-        
-        let imageName = "\(UUID().uuidString).jpeg"
-        let fileReference = userReference.child(docId).child(imageName)
-        
-        print("업로드 시작")
-        
-        //compressionQuality: 1 => 100%를 의미해 압축 없음
-        //이미지가 너무 클 경우 직접 compress하거나 firebase extension 중 resize images(유료)를 사용
-        //이미지 타입이 png라면 data = image.png()
-        guard let data = image.jpegData(compressionQuality: 1) else {
-            print(#function, "Failed to compress image")
-            return
-        }
-        do {
-            let returnedMetaData = try await fileReference.putDataAsync(data, metadata: meta)
-            
-            guard let imageFullPath = returnedMetaData.path else {
-                print(#function, "Failed to get image full path")
-                return
-            }
-            
-            self.imageFullPath = imageFullPath
-        } catch {
-            
-        }
-        print("업로드 종료")
-    }
-    
+    @available(*, deprecated, message: "이 함수는 더이상 사용하지 않습니다. String을 return하는 requestImageURL 함수를 사용 해 주세요. 뷰에서 더이상 사용하는 곳이 없다면 함수를 삭제 해 주세요.")
     func formatToLetterPhoto(fullPath: String, uiImage: UIImage) async throws -> LetterPhoto {
         let item = Storage.storage().reference().child(fullPath)
         let absoluteString = try await item.downloadURL().absoluteString

--- a/PJ3T3_Postie/Model/Letter.swift
+++ b/PJ3T3_Postie/Model/Letter.swift
@@ -19,6 +19,8 @@ struct Letter: Codable, Hashable, Identifiable {
     var text: String
     let isReceived: Bool
     var isFavorite: Bool
+    var imageURLs: [String]?
+    var imageFullPaths: [String]?
 
     static var preview: Letter {
         return Letter(


### PR DESCRIPTION
<!-- 작업 동기에는 해당 작업을 수행한 이유 또는 목적을 간단히 적어주세요. -->
<!-- in progress는 진행중인 연관 이슈, close에는 닫고싶은 issue를 적습니다. -->
## 개요
- in progress
- close #140 
- 작업 요약: 편지 저장 및 수정 로직 변경에 따른 firestore, storage 코드 재구현

<!-- PR의 핵심이 되는 작업 내용을 적어주세요. -->
## 변경 사항
### 새 편지 저장
1. 새 문서 내용 작성 및 이미지 선택해 저장 버튼 클릭
2. 이 문서에 대한 uuid 를 변수로 생성
3. 반복문 시작
4. 이미지 저장
5. 저장 하는 순간 리턴된 fullPath를 newImageFullPaths: [String]에 append
6. 저장된 이미지의 url을 .downloadURL().absoluteString로 fetch해 newImageURLs: [String]에 append
7. 반복문 종료
8. addLetter로 document 저장 -> 코드 업데이트 필요

### 편지 수정
1. 뷰가 init될 때 fullPath와 url을 합친 2차 배열 생성
2. 이미지 삭제 하면 deleteImageURLs: [String]에 append
3. 이미지 삭제 하면 deleteImageFullPaths: [String]에 append
4. 이미지 추가 하면 업로드 예정 배열[UIImage]에 추가
5. 편지 및 사진 수정 후 저장 클릭 
6. 반복문 시작
7. uploadUIImage(image: UIImage, docId: String) 호출: 이미지 한 개 저장
8. 저장 하는 순간 리턴된 fullPath를 newImageFullPaths: [String]에 append
9. 저장된 이미지의 url을 .downloadURL().absoluteString로 fetch
10. 반복문 종료
11. 반복문을 돌며 Storage에서 fullPath로 이미지 삭제
12. firestore에서 arrayRemove()로 url과 fullPath삭제
13. firestore를 editLetter() 함수로 업데이트(arrayUnion활용)

<!-- 노션 팀 페이지에 정리한 글의 링크나 참고한 블로그의 링크를 남겨주세요. -->
## 공유사항(배운 것, 참고하면 좋을 것)
- [Swift Codable을 사용한 Cloud Firestore 데이터 매핑](https://firebase.google.com/docs/firestore/solutions/swift-codable-data-mapping?hl=ko)
- [[Swift] Cloud Firestore(2) 실습해보기](https://hello-developer.tistory.com/53)
- [Cloud Firestore에 데이터 추가](https://firebase.google.com/docs/firestore/manage-data/add-data?hl=ko)

<!-- 이미지 가로 크기 216 고정 -->
## 스크린샷
|제목|작업 전|작업 후|
|:-:|:-:|:-:| 
|사진 추가 버튼||<img width="216" src="https://github.com/APP-iOS3rd/PJ3T3_Postie/assets/106911494/3477fe2e-3aaa-4c78-902c-7b77ae22502f">|

<!-- 질문, 중점적으로 확인받고 싶은 내용 또는 주의사항 등 자유로운 전달사항 적어주세요. -->
## 전달사항
-