### PR TITLE
느린 우체통을 위한 Local Push 설정

### DIFF
--- a/PJ3T3_Postie.xcodeproj/project.pbxproj
+++ b/PJ3T3_Postie.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		9E7E05B92B7DE6D200ACF177 /* FirestoreNoticeManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E7E05B82B7DE6D200ACF177 /* FirestoreNoticeManager.swift */; };
 		9E7E05BB2B7DE96500ACF177 /* OfficialLetter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E7E05BA2B7DE96500ACF177 /* OfficialLetter.swift */; };
 		9E7F8C782B5E69B000F1A6BF /* StorageManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E7F8C772B5E69B000F1A6BF /* StorageManager.swift */; };
+		9E865CC52B839CC300CD7CAD /* NotificationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E865CC42B839CC300CD7CAD /* NotificationManager.swift */; };
 		9E93042D2B745DF1000B7F75 /* Shop.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E93042C2B745DF1000B7F75 /* Shop.swift */; };
 		9E93042F2B74A4B5000B7F75 /* View.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E93042E2B74A4B5000B7F75 /* View.swift */; };
 		9E9A8BE02B6AB09D0072CB75 /* PJ3T3-Postie-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 9E9A8BDF2B6AB09D0072CB75 /* PJ3T3-Postie-Info.plist */; };
@@ -149,6 +150,7 @@
 		9E7E05B82B7DE6D200ACF177 /* FirestoreNoticeManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirestoreNoticeManager.swift; sourceTree = "<group>"; };
 		9E7E05BA2B7DE96500ACF177 /* OfficialLetter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfficialLetter.swift; sourceTree = "<group>"; };
 		9E7F8C772B5E69B000F1A6BF /* StorageManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageManager.swift; sourceTree = "<group>"; };
+		9E865CC42B839CC300CD7CAD /* NotificationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationManager.swift; sourceTree = "<group>"; };
 		9E93042C2B745DF1000B7F75 /* Shop.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Shop.swift; sourceTree = "<group>"; };
 		9E93042E2B74A4B5000B7F75 /* View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = View.swift; sourceTree = "<group>"; };
 		9E9A8BDF2B6AB09D0072CB75 /* PJ3T3-Postie-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = "PJ3T3-Postie-Info.plist"; sourceTree = SOURCE_ROOT; };
@@ -526,6 +528,7 @@
 				9E7E05B82B7DE6D200ACF177 /* FirestoreNoticeManager.swift */,
 				9E7E05B42B7DE54200ACF177 /* FirestoreShopManager.swift */,
 				9E9A8BE82B6B704E0072CB75 /* GoogleSignInHelper.swift */,
+				9E865CC42B839CC300CD7CAD /* NotificationManager.swift */,
 				9E7F8C772B5E69B000F1A6BF /* StorageManager.swift */,
 			);
 			path = Manager;
@@ -832,6 +835,7 @@
 				9E46837C2B7BBBA100EFB90B /* LoadingView.swift in Sources */,
 				9E5889E32B72221B00B4AD20 /* SearchView.swift in Sources */,
 				9E9F6AB82B5762EF003DFE83 /* HomeViewModel.swift in Sources */,
+				9E865CC52B839CC300CD7CAD /* NotificationManager.swift in Sources */,
 				9E9F6ADC2B57643F003DFE83 /* Letter.swift in Sources */,
 				9E9F6AC62B5763A3003DFE83 /* SettingView.swift in Sources */,
 			);

--- a/PJ3T3_Postie/App/PJ3T3_PostieApp.swift
+++ b/PJ3T3_Postie/App/PJ3T3_PostieApp.swift
@@ -33,6 +33,7 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
 struct PJ3T3_PostieApp: App {
     @Environment(\.scenePhase) var scenePhase
     @UIApplicationDelegateAdaptor(AppDelegate.self) var delegate
+    @AppStorage("isThemeGroupButton") private var isThemeGroupButton: Int = 0
     
     private var clientID: String? {
         get { getValueOfPlistFile("MapApiKeys", "NAVER_GEOCODE_ID") }
@@ -45,6 +46,7 @@ struct PJ3T3_PostieApp: App {
     var body: some Scene {
         WindowGroup {
             ContentView()
+                .tint(ThemeManager.themeColors[isThemeGroupButton].tabBarTintColor)
                 .onChange(of: scenePhase) { newPhase in
                     if newPhase == .active {
                         UIApplication.shared.applicationIconBadgeNumber = 0

--- a/PJ3T3_Postie/App/PJ3T3_PostieApp.swift
+++ b/PJ3T3_Postie/App/PJ3T3_PostieApp.swift
@@ -9,7 +9,6 @@ import SwiftUI
 import FirebaseCore
 import NMapsMap
 
-
 class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDelegate {
     func application(_ application: UIApplication,
                      didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {

--- a/PJ3T3_Postie/App/PJ3T3_PostieApp.swift
+++ b/PJ3T3_Postie/App/PJ3T3_PostieApp.swift
@@ -10,13 +10,24 @@ import FirebaseCore
 import NMapsMap
 
 
-class AppDelegate: NSObject, UIApplicationDelegate {
-  func application(_ application: UIApplication,
-                   didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
-    FirebaseApp.configure()
-
-    return true
-  }
+class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDelegate {
+    func application(_ application: UIApplication,
+                     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
+        UNUserNotificationCenter.current().delegate = self
+        FirebaseApp.configure()
+        
+        return true
+    }
+    
+    func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
+        completionHandler([.list, .banner, .badge, .sound])
+    }
+    
+    func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
+        return UISceneConfiguration(name: "Defult Configuration", sessionRole: connectingSceneSession.role)
+    }
+    
+    func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) { }
 }
 
 @main

--- a/PJ3T3_Postie/App/PJ3T3_PostieApp.swift
+++ b/PJ3T3_Postie/App/PJ3T3_PostieApp.swift
@@ -32,7 +32,7 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
 
 @main
 struct PJ3T3_PostieApp: App {
-    // register app delegate for Firebase setup
+    @Environment(\.scenePhase) var scenePhase
     @UIApplicationDelegateAdaptor(AppDelegate.self) var delegate
     
     private var clientID: String? {
@@ -46,6 +46,11 @@ struct PJ3T3_PostieApp: App {
     var body: some Scene {
         WindowGroup {
             ContentView()
+                .onChange(of: scenePhase) { newPhase in
+                    if newPhase == .active {
+                        UIApplication.shared.applicationIconBadgeNumber = 0
+                    }
+                }
         }
     }
 }

--- a/PJ3T3_Postie/Core/Login/View/NicknameView.swift
+++ b/PJ3T3_Postie/Core/Login/View/NicknameView.swift
@@ -47,9 +47,9 @@ struct NicknameView: View {
                             HStack {
                                 Spacer()
                                 if !nickname.isEmpty {
-                                    Button(action: {
+                                    Button{
                                         nickname = ""
-                                    }) {
+                                    } label: {
                                         Image(systemName: "multiply.circle.fill")
                                             .foregroundColor(.postieGray)
                                     }

--- a/PJ3T3_Postie/Core/Login/View/NicknameView.swift
+++ b/PJ3T3_Postie/Core/Login/View/NicknameView.swift
@@ -40,9 +40,23 @@ struct NicknameView: View {
                         .fontWeight(.semibold)
                         .font(.footnote)
                     
-                    TextField("앱에서 사용할 닉네임을 입력 해 주세요", text: $nickname)
+                    TextField("사용할 닉네임을 입력 해 주세요", text: $nickname)
                         .focused($focusField, equals: "nickname")
                         .autocorrectionDisabled()
+                        .overlay(
+                            HStack {
+                                Spacer()
+                                if !nickname.isEmpty {
+                                    Button(action: {
+                                        nickname = ""
+                                    }) {
+                                        Image(systemName: "multiply.circle.fill")
+                                            .foregroundColor(.postieGray)
+                                    }
+                                    .padding(.trailing, 5)
+                                }
+                            }
+                        )
                     
                     Divider()
                     

--- a/PJ3T3_Postie/Core/Setting/View/SettingView.swift
+++ b/PJ3T3_Postie/Core/Setting/View/SettingView.swift
@@ -307,7 +307,7 @@ struct TestDetailView: View {
                     }
                 }
                 
-                DatePicker("DatePicker", selection: $notificationDate, in: Date.now..., displayedComponents: [.date, .hourAndMinute])
+                DatePicker("DatePicker", selection: $notificationDate, in: Date.now..., displayedComponents: [.date])
                     .datePickerStyle(.compact)
             }
             

--- a/PJ3T3_Postie/Core/Setting/View/SettingView.swift
+++ b/PJ3T3_Postie/Core/Setting/View/SettingView.swift
@@ -183,9 +183,9 @@ struct AddDataSectionView: View {
                 let newLetter = Letter(id: docId,
                                        writer: "포스티",
                                        recipient: "포스티팀",
-                                       summary: "이미지 있음, 새 로직",
+                                       summary: "푸시 테스트, 이미지 없음",
                                        date: Date(),
-                                       text: "새 로직으로 업로드 성공!",
+                                       text: "푸시를 삭제하자!",
                                        isReceived: true,
                                        isFavorite: true,
                                        imageURLs: newImageURLs,
@@ -249,6 +249,8 @@ struct TestDetailView: View {
     //새 이미지 추가
     @State private var selectedItem: PhotosPickerItem? = nil
     @State private var selectedImages: [UIImage] = []
+    //푸시 추가
+    @State private var notificationDate = Date.now
     
     var body: some View {
         ScrollView {
@@ -304,9 +306,19 @@ struct TestDetailView: View {
                         }
                     }
                 }
+                
+                DatePicker("DatePicker", selection: $notificationDate, in: Date.now..., displayedComponents: [.date, .hourAndMinute])
+                    .datePickerStyle(.compact)
             }
             
             HStack {
+                Button {
+                    setNotification(docId: letter.id, date: notificationDate)
+                } label: {
+                    Text("푸시 추가")
+                }
+                .buttonStyle(.borderedProminent)
+                
                 PhotosPicker(selection: $selectedItem, matching: .images, photoLibrary: .shared()) {
                     Text("사진 추가")
                 }
@@ -323,6 +335,7 @@ struct TestDetailView: View {
                     firestoreManager.deleteLetter(documentId: letter.id)
                     storageManager.deleteFolder(docId: letter.id)
                     firestoreManager.fetchAllLetters()
+                    NotificationManager.shared.removePendingNotificationRequests(docId: letter.id)
                     dismiss()
                 } label: {
                     Text("삭제")
@@ -339,6 +352,13 @@ struct TestDetailView: View {
             }
             selectedItem = nil
         }
+    }
+    
+    func setNotification(docId: String, date: Date) {
+        let manager = NotificationManager.shared
+        //title이나 body 부분의 문구 여러가지로 배열 작성 해 두었다가 알람 뜰 때 랜덤으로 설정되면 좋을 것 같아요~
+        manager.addNotification(id: docId, title: "포스티", body: "포스티가 편지를 배달했어요")
+        manager.setNotification(date: date)
     }
     
     func initLetterDetail() {

--- a/PJ3T3_Postie/Core/Setting/View/SettingView.swift
+++ b/PJ3T3_Postie/Core/Setting/View/SettingView.swift
@@ -469,11 +469,9 @@ struct NoticeTestView: View {
     @ObservedObject var firestoreNoticeManager = FirestoreNoticeManager.shared
     
     var body: some View {
-        VStack {            
-            Section {
-                ForEach(firestoreNoticeManager.notices, id:\.self) { notice in
-                    Text(notice.title)
-                }
+        Section("Notices") {
+            ForEach(firestoreNoticeManager.notices, id:\.self) { notice in
+                Text(notice.title)
             }
         }
         .onAppear {

--- a/PJ3T3_Postie/Core/Setting/View/SettingView.swift
+++ b/PJ3T3_Postie/Core/Setting/View/SettingView.swift
@@ -357,7 +357,7 @@ struct TestDetailView: View {
     func setNotification(docId: String, date: Date) {
         let manager = NotificationManager.shared
         //title이나 body 부분의 문구 여러가지로 배열 작성 해 두었다가 알람 뜰 때 랜덤으로 설정되면 좋을 것 같아요~
-        manager.addNotification(id: docId, title: "포스티", body: "포스티가 편지를 배달했어요")
+        manager.addNotification(id: docId, title: "포스티가 편지를 배달했어요", body: summary.count == 0 ? "포스티에서 내용을 확인 해 보세요" : summary)
         manager.setNotification(date: date)
     }
     

--- a/PJ3T3_Postie/Manager/NotificationManager.swift
+++ b/PJ3T3_Postie/Manager/NotificationManager.swift
@@ -5,4 +5,84 @@
 //  Created by Eunsu JEONG on 2/19/24.
 //
 
-import Foundation
+import UserNotifications
+import UIKit
+
+struct Notification {
+    var id: String
+    var title: String
+    var body: String
+}
+
+class NotificationManager {
+    static let shared = NotificationManager()
+    let notificationCenter = UNUserNotificationCenter.current()
+    var notifications = [Notification]()
+    
+    private init() { }
+    
+    /// 알림 권한이 있으면 바로 알림을 추가하고 권한이 없으면 권한을 요청한다. 편지 저장하는 버튼의 마지막 단계에 연결하면 좋을 듯 하다.
+    func setNotification(date: Date) {
+        notificationCenter.getNotificationSettings { settings in
+            switch settings.authorizationStatus {
+            case .notDetermined:
+                self.requestPermission()
+            case .authorized, .provisional:
+                DispatchQueue.main.async {
+                    self.scheduleNotifications(date: date)
+                }
+            default:
+                break
+            }
+        }
+    }
+    
+    /// 뱃지, 사운드, 알림에 대한 권한을 요청한다.
+    func requestPermission() {
+        notificationCenter.requestAuthorization(options: [.alert, .badge, .sound]) { granted, error in
+                if granted == true && error == nil { }
+            }
+    }
+    
+    /// 알림을 추가한다.
+    func addNotification(id: String, title: String, body: String) {
+        notifications.append(Notification(id: id, title: title, body: body))
+    }
+    
+    ///날짜를 파라미터로 받아 알람을 설정한다.
+    func scheduleNotifications(date: Date) {
+        for notification in notifications {
+            let content = UNMutableNotificationContent()
+            content.title = notification.title
+            content.body = notification.body
+            content.sound = .default
+            content.badge = NSNumber(value: UIApplication.shared.applicationIconBadgeNumber + 1)
+            
+            let date = Calendar.current.dateComponents([.year, .month, .day, .hour, .minute], from: date)
+            let trigger = UNCalendarNotificationTrigger(dateMatching: date, repeats: false)
+            let request = UNNotificationRequest(identifier: notification.id, content: content, trigger: trigger)
+            
+            notificationCenter.add(request) { error in
+                    guard error == nil else {
+                        print(#function, "Failed to schedule notification", error)
+                        return
+                    }
+                    print("Scheduling notification with id: \(notification.id)")
+                }
+        }
+    }
+    
+    ///아직 전달되지 않은 알림이 있는지 확인한다.
+    func checkPendingNotifications() {
+        notificationCenter.getPendingNotificationRequests { requests in
+            for request in requests {
+                print(#function, request.identifier)
+            }
+        }
+    }
+    
+    ///docId를 input 받아 알림을 삭제한다.
+    func removePendingNotificationRequests(docId: String) {
+        notificationCenter.removePendingNotificationRequests(withIdentifiers: [docId])
+    }
+}

--- a/PJ3T3_Postie/Manager/NotificationManager.swift
+++ b/PJ3T3_Postie/Manager/NotificationManager.swift
@@ -1,0 +1,8 @@
+//
+//  NotificationManager.swift
+//  PJ3T3_Postie
+//
+//  Created by Eunsu JEONG on 2/19/24.
+//
+
+import Foundation

--- a/PJ3T3_Postie/Manager/NotificationManager.swift
+++ b/PJ3T3_Postie/Manager/NotificationManager.swift
@@ -58,7 +58,10 @@ class NotificationManager {
             content.sound = .default
             content.badge = NSNumber(value: UIApplication.shared.applicationIconBadgeNumber + 1)
             
-            let date = Calendar.current.dateComponents([.year, .month, .day, .hour, .minute], from: date)
+            var date = Calendar.current.dateComponents([.year, .month, .day], from: date)
+            date.hour = 09
+            date.minute = 00
+            
             let trigger = UNCalendarNotificationTrigger(dateMatching: date, repeats: false)
             let request = UNNotificationRequest(identifier: notification.id, content: content, trigger: trigger)
             


### PR DESCRIPTION
<!-- 작업 동기에는 해당 작업을 수행한 이유 또는 목적을 간단히 적어주세요. -->
<!-- in progress는 진행중인 연관 이슈, close에는 닫고싶은 issue를 적습니다. -->
## 개요
- in progress
- close #139 
- 작업 요약: 날짜와 시간을 설정하면 해당 시간과 날짜에 push 알림을 보낸다.

<!-- PR의 핵심이 되는 작업 내용을 적어주세요. -->
## 변경 사항
- NotificationManager 생성
  - 알림 권한이 있으면 바로 알림을 추가하고 권한이 없으면 권한을 요청
    - 편지 저장하는 버튼의 마지막 step에 연결 예상
  - 알림 추가
  - 날짜를 파라미터로 받아 알람을 설정
  - 아직 전달되지 않은 알림이 있는지 확인
  - docId를 input 받아 알림을 삭제
- 알람이 여러개 오면 숫자가 늘어남
- 앱을 실행하면 뱃지의 숫자가 사라짐
- SettingView에서 테스트 진행
  - 세팅 뷰의 편지 항목을 눌러 들어가면 알림 설정 및 편지 삭제시 알림 삭제 테스트 가능

<!-- 노션 팀 페이지에 정리한 글의 링크나 참고한 블로그의 링크를 남겨주세요. -->
## 공유사항(배운 것, 참고하면 좋을 것)
- [대기중인 알림 확인, 알림 삭제](https://green1229.tistory.com/71)
  - removeDeliveredNotifications와 removePendingNotificationRequests의 차이점
- [How to use Local Notification in SwiftUI: 코드의 대부분을 참고한 블로그](https://medium.com/@jeongjaeyn/how-to-use-local-notification-in-swiftui-87a091b920e2)
- [UserNotification(Local Notification): 날짜와 시간으로 푸시 설정](https://swifty-cody.tistory.com/41)
- [[iOS/Swift] 'alert' was deprecated in iOS 14.0](https://velog.io/@preference/alert-was-deprecated-in-iOS-14.0)

<!-- 이미지 가로 크기 216 고정 -->
## 스크린샷
|제목|작업 후1|작업 후2|작업 후3|
|:-:|:-:|:-:|:-:|
|알림|<img width="216" src="https://github.com/APP-iOS3rd/PJ3T3_Postie/assets/106911494/03555aec-59bb-4bfc-8ff8-55d5948c19fe">|<img width="216" src="https://github.com/APP-iOS3rd/PJ3T3_Postie/assets/106911494/850fc38c-81f8-4eb9-ab12-2b436d67436f">|<img width="216" src="https://github.com/APP-iOS3rd/PJ3T3_Postie/assets/106911494/a999af9c-d17f-44c5-b0ee-e8f75f3c956d">|

<!-- 질문, 중점적으로 확인받고 싶은 내용 또는 주의사항 등 자유로운 전달사항 적어주세요. -->
## 전달사항
- 느린 우체통 뷰 어떻게 하죠...?
- 이어서 뷰 및 필터 기능 구현 부탁드립니다!
