### PR TITLE
닉네임뷰 버그 해결 및 회원가입, 탈퇴 오류 에러 핸들링

### DIFF
--- a/PJ3T3_Postie.xcodeproj/project.pbxproj
+++ b/PJ3T3_Postie.xcodeproj/project.pbxproj
@@ -85,6 +85,7 @@
 		9E9F6B162B5769AA003DFE83 /* FirebaseStorage in Frameworks */ = {isa = PBXBuildFile; productRef = 9E9F6B152B5769AA003DFE83 /* FirebaseStorage */; };
 		9EA106772B63C5C90033E7A8 /* LetterPhoto.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EA106762B63C5C90033E7A8 /* LetterPhoto.swift */; };
 		9EBAFDC42B70ED900020EE6F /* AppleSignInHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EBAFDC32B70ED900020EE6F /* AppleSignInHelper.swift */; };
+		9EE31F9B2B84B19900B11D70 /* ReAuthButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EE31F9A2B84B19900B11D70 /* ReAuthButtonView.swift */; };
 		CE4F1AD22B7CDF8800FE7CF6 /* EditLetterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE4F1AD12B7CDF8800FE7CF6 /* EditLetterView.swift */; };
 		CE4F1AD42B7CE06D00FE7CF6 /* EditLetterViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE4F1AD32B7CE06D00FE7CF6 /* EditLetterViewModel.swift */; };
 		CE5FF9272B6CF8A400DDA5BF /* NanumMyeongjo.otf in Resources */ = {isa = PBXBuildFile; fileRef = CE5FF9262B6CF8A400DDA5BF /* NanumMyeongjo.otf */; };
@@ -183,6 +184,7 @@
 		9E9F6ADE2B5765DD003DFE83 /* Color.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Color.swift; sourceTree = "<group>"; };
 		9EA106762B63C5C90033E7A8 /* LetterPhoto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LetterPhoto.swift; sourceTree = "<group>"; };
 		9EBAFDC32B70ED900020EE6F /* AppleSignInHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleSignInHelper.swift; sourceTree = "<group>"; };
+		9EE31F9A2B84B19900B11D70 /* ReAuthButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReAuthButtonView.swift; sourceTree = "<group>"; };
 		CE4F1AD12B7CDF8800FE7CF6 /* EditLetterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditLetterView.swift; sourceTree = "<group>"; };
 		CE4F1AD32B7CE06D00FE7CF6 /* EditLetterViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditLetterViewModel.swift; sourceTree = "<group>"; };
 		CE5FF9262B6CF8A400DDA5BF /* NanumMyeongjo.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = NanumMyeongjo.otf; sourceTree = "<group>"; };
@@ -372,6 +374,7 @@
 				9E9F6ACF2B5763D0003DFE83 /* LoginInputView.swift */,
 				9E9F6AC92B5763B8003DFE83 /* LoginView.swift */,
 				9E9A8BF22B6CD8990072CB75 /* NicknameView.swift */,
+				9EE31F9A2B84B19900B11D70 /* ReAuthButtonView.swift */,
 				9E9F6ACB2B5763C3003DFE83 /* RegistrationView.swift */,
 			);
 			path = View;
@@ -798,6 +801,7 @@
 				9E9F6ADF2B5765DE003DFE83 /* Color.swift in Sources */,
 				0E29F0D82B5FA2FC005B86FB /* Button.swift in Sources */,
 				9E9F6ABA2B5762FC003DFE83 /* MapView.swift in Sources */,
+				9EE31F9B2B84B19900B11D70 /* ReAuthButtonView.swift in Sources */,
 				9E7E05B92B7DE6D200ACF177 /* FirestoreNoticeManager.swift in Sources */,
 				9E9F6ACC2B5763C3003DFE83 /* RegistrationView.swift in Sources */,
 				9E9F6ABC2B576351003DFE83 /* MapCoordinator.swift in Sources */,

--- a/PJ3T3_Postie/Core/Login/View/DeleteAccountButtonView.swift
+++ b/PJ3T3_Postie/Core/Login/View/DeleteAccountButtonView.swift
@@ -27,7 +27,7 @@ struct DeleteAccountButtonView: View {
                         try await authManager.deleteAccount()
                         showLoading = true
                     } catch {
-                        print(#function, "Failed to delete Google account: \(error)")
+                        googleLoginFailure(error: error)
                         showLoading = false
                     }
                 }
@@ -47,6 +47,20 @@ struct DeleteAccountButtonView: View {
             } else {
                 showLoading = true
             }
+        }
+    }
+    
+    func googleLoginFailure(error: Error) {
+        switch error {
+        case AuthErrorCodeCase.userMismatch:
+            alertBody = "현재 로그인중인 사용자가 아니에요. 계정을 다시 확인 해 주세요."
+        case GIDSignInErrorCode.canceled:
+            alertBody = "재인증이 취소되었습니다. 회원 탈퇴를 위해서는 계정 재인증을 위한 로그인이 필요합니다."
+        case AuthErrorCodeCase.requiresRecentLogin:
+            alertBody = "재인증이 취소되었습니다. 회원 탈퇴를 위해서는 계정 재인증을 위한 로그인이 필요합니다."
+        default:
+            alertBody = "알 수 없는 오류가 발생하였습니다. 회원 탈퇴를 위해서는 관리자에게 문의 해 주세요.\nteam.postie@google.com"
+            print(#function, "Failed to delete Google account: \(error)")
         }
     }
 }

--- a/PJ3T3_Postie/Core/Login/View/DeleteAccountButtonView.swift
+++ b/PJ3T3_Postie/Core/Login/View/DeleteAccountButtonView.swift
@@ -32,7 +32,8 @@ struct DeleteAccountButtonView: View {
                 }
             case .apple:
                 print("Delete Apple account")
-                AppleSignInHelper.shared.deleteCurrentAppleUser()
+                AppleSignInHelper.shared.reAuthCurrentAppleUser()
+                showLoading = true
             default:
                 print("Delete account")
                 //alert 창 구현

--- a/PJ3T3_Postie/Core/Login/View/DeleteAccountButtonView.swift
+++ b/PJ3T3_Postie/Core/Login/View/DeleteAccountButtonView.swift
@@ -24,6 +24,7 @@ struct DeleteAccountButtonView: View {
                 Task {
                     do {
                         try await authManager.deleteGoogleAccount()
+                        authManager.deleteAccount()
                         showLoading = true
                     } catch {
                         print(#function, "Failed to delete Google account: \(error)")

--- a/PJ3T3_Postie/Core/Login/View/DeleteAccountButtonView.swift
+++ b/PJ3T3_Postie/Core/Login/View/DeleteAccountButtonView.swift
@@ -10,6 +10,8 @@ import SwiftUI
 struct DeleteAccountButtonView: View {
     @ObservedObject var authManager = AuthManager.shared
     @Binding var showLoading: Bool
+    @Binding var showAlert: Bool
+    @Binding var alertBody: String
     
     var body: some View {
         Button("계정 삭제", role: .destructive) {
@@ -29,6 +31,7 @@ struct DeleteAccountButtonView: View {
                     } catch {
                         googleLoginFailure(error: error)
                         showLoading = false
+                        showAlert = true
                     }
                 }
             case .apple:
@@ -66,5 +69,5 @@ struct DeleteAccountButtonView: View {
 }
 
 #Preview {
-    DeleteAccountButtonView(showLoading: .constant(false))
+    DeleteAccountButtonView(showLoading: .constant(false), showAlert: .constant(false), alertBody: .constant("프리뷰"))
 }

--- a/PJ3T3_Postie/Core/Login/View/DeleteAccountButtonView.swift
+++ b/PJ3T3_Postie/Core/Login/View/DeleteAccountButtonView.swift
@@ -24,7 +24,7 @@ struct DeleteAccountButtonView: View {
                 Task {
                     do {
                         try await authManager.deleteGoogleAccount()
-                        authManager.deleteAccount()
+                        try await authManager.deleteAccount()
                         showLoading = true
                     } catch {
                         print(#function, "Failed to delete Google account: \(error)")

--- a/PJ3T3_Postie/Core/Login/View/DeleteAccountButtonView.swift
+++ b/PJ3T3_Postie/Core/Login/View/DeleteAccountButtonView.swift
@@ -26,8 +26,8 @@ struct DeleteAccountButtonView: View {
                 Task {
                     do {
                         try await authManager.deleteGoogleAccount()
-                        try await authManager.deleteAccount()
                         showLoading = true
+                        try await authManager.deleteAccount()
                     } catch {
                         googleLoginFailure(error: error)
                         showLoading = false

--- a/PJ3T3_Postie/Core/Login/View/LoginView.swift
+++ b/PJ3T3_Postie/Core/Login/View/LoginView.swift
@@ -98,12 +98,14 @@ struct LoginView: View {
                     NavigationLink {
                         EmailLoginView()
                     } label: {
-                        HStack {
+                        HStack(spacing: 0) {
                             Text("테스트용 이메일 계정으로")
                                 .foregroundColor(postieColors.tabBarTintColor)
                             
                             Text("로그인 하기")
                                 .foregroundColor(postieColors.tintColor)
+                                .bold()
+                                .padding(.leading, 4)
                         }
                     }
                     .padding(.bottom, 10)

--- a/PJ3T3_Postie/Core/Login/View/NicknameView.swift
+++ b/PJ3T3_Postie/Core/Login/View/NicknameView.swift
@@ -18,10 +18,8 @@ struct NicknameView: View {
     @State private var dialogMessage = ""
     @State private var loadingText = ""
     @FocusState private var focusField: String?
-    @AppStorage("isThemeGroupButton") private var isThemeGroupButton: Int = 0
     
     var body: some View {
-        let postieColors = ThemeManager.themeColors[isThemeGroupButton]
         
         ZStack {
             postieColors.backGroundColor

--- a/PJ3T3_Postie/Core/Login/View/NicknameView.swift
+++ b/PJ3T3_Postie/Core/Login/View/NicknameView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct NicknameView: View {
     @ObservedObject var authManager = AuthManager.shared
     @State var nickname: String = ""
-    @State var isTappable: Bool = false
+    @State private var isTappable: Bool = false
     @State private var showAlert = false
     @State private var isDialogPresented = false
     @State private var showLoading = false
@@ -36,9 +36,10 @@ struct NicknameView: View {
                         .fontWeight(.semibold)
                         .font(.footnote)
                     
-                    TextField("앱에서 사용할 닉네임을 입력 해 주세요", text: $nickname)
+                    TextField("사용할 닉네임을 입력 해 주세요", text: $nickname)
                         .focused($focusField, equals: "nickname")
                         .autocorrectionDisabled()
+                        .foregroundStyle(postieColors.dividerColor)
                     
                     Divider()
                     

--- a/PJ3T3_Postie/Core/Login/View/NicknameView.swift
+++ b/PJ3T3_Postie/Core/Login/View/NicknameView.swift
@@ -14,8 +14,6 @@ struct NicknameView: View {
     @State private var showAlert = false
     @State private var isDialogPresented = false
     @State private var showLoading = false
-    @State private var dialogTitle = ""
-    @State private var dialogMessage = ""
     @State private var loadingText = ""
     @FocusState private var focusField: String?
     
@@ -119,11 +117,8 @@ struct NicknameView: View {
                     let confirmButton = Alert.Button.default(Text("좋아요")) {
                         Task {
                             guard let authDataResult = authManager.authDataResult else {
-                                dialogTitle = "계정 정보를 가져오는데 실패했습니다."
-                                dialogMessage = "재인증을 통해 로그인 정보를 삭제한 다음 다시 회원가입 해 주세요."
-                                loadingText = "계정을 안전하게 삭제하는 중이에요"
                                 isDialogPresented = true
-                                nickname = ""
+                                isTappable = true
                                 return
                             }
                             
@@ -138,28 +133,14 @@ struct NicknameView: View {
             }
             .padding(.horizontal, 32)
             .padding(.bottom, 100)
-            
-            VStack {
-                Spacer()
-                
-                Button {
-                    dialogTitle = "이미 존재하는 계정입니다."
-                    dialogMessage = "계정 삭제를 위해서는 재인증을 통해 다시 로그인 해야 합니다."
-                    loadingText = "계정을 안전하게 삭제하는 중이에요"
-                    isDialogPresented = true
-                } label: {
-                    Text("Back to Login Selection")
-                        .foregroundStyle(postieColors.tintColor)
-                }
-            }
         }
         .onTapGesture {
             hideKeyboard()
         }
-        .confirmationDialog(dialogTitle, isPresented: $isDialogPresented, titleVisibility: .visible) {
-            DeleteAccountButtonView(showLoading: $showLoading)
+        .confirmationDialog("계정 정보를 가져오는데 실패했습니다.", isPresented: $isDialogPresented, titleVisibility: .visible) {
+            ReAuthButtonView(showLoading: $showLoading, nickname: $nickname)
         } message: {
-            Text(dialogMessage)
+            Text("계정 생성을 위해 재인증이 필요합니다. 재인증이 완료 되면 버튼을 다시 한 번 눌러주세요.")
                 .multilineTextAlignment(.center)
         }
         .fullScreenCover(isPresented: $showLoading) {

--- a/PJ3T3_Postie/Core/Login/View/NicknameView.swift
+++ b/PJ3T3_Postie/Core/Login/View/NicknameView.swift
@@ -83,6 +83,14 @@ struct NicknameView: View {
                 
                 Button {
                     isTappable = false
+                    guard authManager.authDataResult != nil else {
+                        hideKeyboard()
+                        loadingText = "계정을 확인하고 있어요"
+                        isTappable = true
+                        isDialogPresented = true
+                        return
+                    }
+                    
                     showAlert = true
                 } label: {
                     HStack() {

--- a/PJ3T3_Postie/Core/Login/View/NicknameView.swift
+++ b/PJ3T3_Postie/Core/Login/View/NicknameView.swift
@@ -11,10 +11,12 @@ struct NicknameView: View {
     @ObservedObject var authManager = AuthManager.shared
     @State var nickname: String = ""
     @State private var isTappable: Bool = false
-    @State private var showAlert = false
+    @State private var showSuccessAlert = false
+    @State private var showFailureAlert = false
     @State private var isDialogPresented = false
     @State private var showLoading = false
     @State private var loadingText = ""
+    @State private var failureAlertMessage = ""
     @FocusState private var focusField: String?
     
     var body: some View {
@@ -92,7 +94,7 @@ struct NicknameView: View {
                         return
                     }
                     
-                    showAlert = true
+                    showSuccessAlert = true
                 } label: {
                     HStack() {
                         Image(systemName: "envelope")
@@ -117,7 +119,7 @@ struct NicknameView: View {
                         isTappable = false
                     }
                 }
-                .alert(isPresented: $showAlert) {
+                .alert(isPresented: $showSuccessAlert) {
                     let title = Text("닉네임 설정")
                     let message = Text(#"한 번 설정한 닉네임은 변경할 수 없으니 신중하게 선택해주세요! \#n "\#(nickname)"으로 시작하시겠습니까?"#)
                     let cancelButton = Alert.Button.destructive(Text("취소")) {
@@ -139,6 +141,13 @@ struct NicknameView: View {
                     
                     return Alert(title: title, message: message, primaryButton: cancelButton, secondaryButton: confirmButton)
                 }
+                .alert("인증 실패", isPresented: $showFailureAlert) {
+                    Button(role: .cancel, action: { }) {
+                        Text("확인")
+                    }
+                } message: {
+                    Text(failureAlertMessage)
+                }
             }
             .padding(.horizontal, 32)
             .padding(.bottom, 100)
@@ -147,7 +156,7 @@ struct NicknameView: View {
             hideKeyboard()
         }
         .confirmationDialog("계정 정보를 가져오는데 실패했습니다.", isPresented: $isDialogPresented, titleVisibility: .visible) {
-            ReAuthButtonView(showLoading: $showLoading, nickname: $nickname)
+            ReAuthButtonView(showLoading: $showLoading, showAlert: $showFailureAlert, alertBody: $failureAlertMessage)
         } message: {
             Text("계정 생성을 위해 재인증이 필요합니다. 재인증이 완료 되면 버튼을 다시 한 번 눌러주세요.")
                 .multilineTextAlignment(.center)

--- a/PJ3T3_Postie/Core/Login/View/ReAuthButtonView.swift
+++ b/PJ3T3_Postie/Core/Login/View/ReAuthButtonView.swift
@@ -1,0 +1,18 @@
+//
+//  ReAuthButtonView.swift
+//  PJ3T3_Postie
+//
+//  Created by Eunsu JEONG on 2/20/24.
+//
+
+import SwiftUI
+
+struct ReAuthButtonView: View {
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}
+
+#Preview {
+    ReAuthButtonView()
+}

--- a/PJ3T3_Postie/Core/Login/View/ReAuthButtonView.swift
+++ b/PJ3T3_Postie/Core/Login/View/ReAuthButtonView.swift
@@ -6,13 +6,49 @@
 //
 
 import SwiftUI
+import AuthenticationServices
 
 struct ReAuthButtonView: View {
+    @ObservedObject var authManager = AuthManager.shared
+    @Binding var showLoading: Bool
+    @Binding var nickname: String
+    
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        Button("계정 재인증") {
+            switch authManager.provider {
+            case .google:
+                print("Re-Auth Google account")
+                Task {
+                    do {
+                        let credential = try await authManager.signInWithGoogle()
+                        showLoading = true
+                        authManager.authDataResult = try await authManager.signInWithSSO(credential: credential)
+                        showLoading = false
+                    } catch {
+                        print(#function, "Failed to re-auth Google account: \(error)")
+                        showLoading = false
+                    }
+                }
+            case .apple:
+                print("Re-Auth Apple account")
+                AppleSignInHelper.shared.isReAuth = true
+                AppleSignInHelper.shared.reAuthCurrentAppleUser()
+            default:
+                print("Cannot re-auth account")
+                //alert 창 구현
+            }
+        }
+        .customOnChange(authManager.credential) { newValue in
+            if authManager.credential == nil {
+                print(#function, "Canceled to delete account")
+                showLoading = false
+            } else {
+                showLoading = true
+            }
+        }
     }
 }
 
 #Preview {
-    ReAuthButtonView()
+    ReAuthButtonView(showLoading: .constant(false), nickname: .constant("포스티"))
 }

--- a/PJ3T3_Postie/Core/Login/View/ReAuthButtonView.swift
+++ b/PJ3T3_Postie/Core/Login/View/ReAuthButtonView.swift
@@ -11,7 +11,8 @@ import AuthenticationServices
 struct ReAuthButtonView: View {
     @ObservedObject var authManager = AuthManager.shared
     @Binding var showLoading: Bool
-    @Binding var nickname: String
+    @Binding var showAlert: Bool
+    @Binding var alertBody: String
     
     var body: some View {
         Button("계정 재인증") {
@@ -35,6 +36,7 @@ struct ReAuthButtonView: View {
                             }
                         }
                         showLoading = false
+                        showAlert = true
                     }
                 }
             case .apple:
@@ -73,5 +75,5 @@ struct ReAuthButtonView: View {
 }
 
 #Preview {
-    ReAuthButtonView(showLoading: .constant(false), nickname: .constant("포스티"))
+    ReAuthButtonView(showLoading: .constant(false), showAlert: .constant(false), alertBody: .constant("프리뷰"))
 }

--- a/PJ3T3_Postie/Core/Login/View/ReAuthButtonView.swift
+++ b/PJ3T3_Postie/Core/Login/View/ReAuthButtonView.swift
@@ -10,8 +10,8 @@ import AuthenticationServices
 
 struct ReAuthButtonView: View {
     @ObservedObject var authManager = AuthManager.shared
-    @Binding var showLoading: Bool
-    @Binding var showAlert: Bool
+    @Binding var showFailureAlert: Bool
+    @Binding var showSuccessAlert: Bool
     @Binding var alertBody: String
     
     var body: some View {
@@ -22,9 +22,7 @@ struct ReAuthButtonView: View {
                 Task {
                     do {
                         let credential = try await authManager.signInWithGoogle()
-                        showLoading = true
                         authManager.authDataResult = try await authManager.signInWithSSO(credential: credential)
-                        showLoading = false
                     } catch let error as NSError {
                         if error.code == GIDSignInErrorCode.canceled.rawValue {
                             alertBody = "재인증이 취소되었습니다. 계정 생성을 위해서는 재인증을 해 주세요."
@@ -35,8 +33,7 @@ struct ReAuthButtonView: View {
                                 googleLoginFailure(error: error)
                             }
                         }
-                        showLoading = false
-                        showAlert = true
+                        showFailureAlert = true
                     }
                 }
             case .apple:
@@ -48,12 +45,13 @@ struct ReAuthButtonView: View {
                 //alert 창 구현
             }
         }
-        .customOnChange(authManager.credential) { newValue in
-            if authManager.credential == nil {
-                print(#function, "Canceled to delete account")
-                showLoading = false
+        .customOnChange(authManager.authDataResult) { newValue in
+            if authManager.authDataResult == nil {
+                print(#function, "on change authDataResult nil")
+                showSuccessAlert = false
             } else {
-                showLoading = true
+                print(#function, "on change authDataResult not nil")
+                showSuccessAlert = true
             }
         }
     }
@@ -75,5 +73,5 @@ struct ReAuthButtonView: View {
 }
 
 #Preview {
-    ReAuthButtonView(showLoading: .constant(false), showAlert: .constant(false), alertBody: .constant("프리뷰"))
+    ReAuthButtonView(showFailureAlert: .constant(false), showSuccessAlert: .constant(false), alertBody: .constant("프리뷰"))
 }

--- a/PJ3T3_Postie/Core/Root/View/ContentView.swift
+++ b/PJ3T3_Postie/Core/Root/View/ContentView.swift
@@ -61,12 +61,12 @@ struct ContentView: View {
                                     Text("Map")
                                 }
                             
-                            //테스트용 뷰입니다. 추후 삭제 예정입니다.
-                            SettingView()
-                                .tabItem {
-                                    Image(systemName: "person")
-                                    Text("Setting")
-                                }
+                            //테스트용 뷰입니다. 배포시 주석처리
+//                            SettingView()
+//                                .tabItem {
+//                                    Image(systemName: "person")
+//                                    Text("Setting")
+//                                }
                         }
                         .accentColor(ThemeManager.themeColors[isThemeGroupButton].tabBarTintColor)
                     } else {

--- a/PJ3T3_Postie/Core/Setting/View/SettingView.swift
+++ b/PJ3T3_Postie/Core/Setting/View/SettingView.swift
@@ -19,6 +19,8 @@ struct SettingView: View {
     @State private var summary: String = ""
     @State private var isDeleteAccountDialogPresented = false
     @State private var showLoading = false
+    @State private var showAlert = false
+    @State private var alertBody = ""
     
     var body: some View {
         NavigationStack {
@@ -103,6 +105,13 @@ struct SettingView: View {
                             SettingsRowView(imageName: "xmark.circle.fill", title: "Delete Account", tintColor: signOutIconColor)
                         }
                     }
+                    .alert(isPresented: $showAlert) {
+                        let title = Text("탈퇴 실패")
+                        let message = Text(alertBody)
+                        let confirmButton = Alert.Button.cancel(Text("확인"))
+
+                        return Alert(title: title, message: message, dismissButton: confirmButton)
+                    }
                     
                     NoticeTestView()
                     
@@ -121,7 +130,7 @@ struct SettingView: View {
             appleSignInHelper.window = window
         }
         .confirmationDialog("포스티를 떠나시나요?", isPresented: $isDeleteAccountDialogPresented, titleVisibility: .visible) {
-            DeleteAccountButtonView(showLoading: $showLoading)
+            DeleteAccountButtonView(showLoading: $showLoading, showAlert: $showAlert, alertBody: $alertBody)
         } message: {
             Text("회원 탈퇴 시에는 계정과 프로필 정보, 그리고 등록된 모든 편지와 편지 이미지가 삭제되며 복구할 수 없습니다. 계정 삭제를 위해서는 재인증을 통해 다시 로그인 해야 합니다.")
         }

--- a/PJ3T3_Postie/Manager/AppleSignInHelper.swift
+++ b/PJ3T3_Postie/Manager/AppleSignInHelper.swift
@@ -60,7 +60,7 @@ final class AppleSignInHelper: NSObject, ObservableObject {
         }
     }
     
-    func deleteCurrentAppleUser() {
+    func reAuthCurrentAppleUser() {
         let appleIDProvider = ASAuthorizationAppleIDProvider()
         let request = appleIDProvider.createRequest()
         

--- a/PJ3T3_Postie/Manager/AppleSignInHelper.swift
+++ b/PJ3T3_Postie/Manager/AppleSignInHelper.swift
@@ -13,6 +13,7 @@ final class AppleSignInHelper: NSObject, ObservableObject {
     private var nonce = ""
     var cryptoUtils: CryptoUtils?
     var window: UIWindow?
+    var isReAuth = false
     
     private override init() { }
     
@@ -127,7 +128,17 @@ extension AppleSignInHelper: ASAuthorizationControllerDelegate {
         AuthManager.shared.signInwithApple(user: appleUser)
         
         Task {
-            await AuthManager.shared.deleteAppleAccount(authCodeString: authCodeString)
+            if !self.isReAuth {
+                await AuthManager.shared.deleteAppleAccount(user: appleUser, authCodeString: authCodeString)
+            } else {
+                do {
+                    print("Called Reauth")
+                    try await AuthManager.shared.reAuthAppleAccount(user: appleUser)
+                    isReAuth = false
+                } catch {
+                    print(#function, "Failed to re-auth Apple account: \(error)")
+                }
+            }
         }
     }
 }

--- a/PJ3T3_Postie/Manager/AuthCaseHelper.swift
+++ b/PJ3T3_Postie/Manager/AuthCaseHelper.swift
@@ -22,3 +22,8 @@ enum GIDSignInErrorCode: NSInteger, Error {
     case scopesAlreadyGranted = -8 //Indicates the requested scopes have already been granted to the currentUser.
     case mismatchWithCurrentUser = -9 //Indicates there is an operation on a previous user.
 }
+
+enum AuthErrorCodeCase: Error {
+    case userMismatch //로그인 한 유저와 탈퇴 인증 한 유저가 다를 경우
+    case requiresRecentLogin //재인증 과정 중 취소 한 경우
+}

--- a/PJ3T3_Postie/Manager/AuthManager.swift
+++ b/PJ3T3_Postie/Manager/AuthManager.swift
@@ -233,6 +233,8 @@ extension AuthManager {
         } catch let error as NSError {
             if error.code == GIDSignInErrorCode.canceled.rawValue {
                 throw GIDSignInErrorCode.canceled
+            } else if let _ = AuthErrorCode.Code(rawValue: error.code) {
+                try authErrorCodeConverter(error: error)
             } else {
                 print(#function, "Failed to delete Google account: \(error)")
             }

--- a/PJ3T3_Postie/Manager/AuthManager.swift
+++ b/PJ3T3_Postie/Manager/AuthManager.swift
@@ -183,6 +183,19 @@ class AuthManager: ObservableObject {
             }
         }
     }
+    
+    func authErrorCodeConverter(error: NSError) throws {
+        let errorCode = AuthErrorCode.Code(rawValue: error.code)
+        
+        switch errorCode {
+        case .userMismatch:
+            throw AuthErrorCodeCase.userMismatch
+        case .requiresRecentLogin:
+            throw AuthErrorCodeCase.requiresRecentLogin
+        default:
+            print(#function, "Failed to delete Google account AuthErrorCode: \(error)")
+        }
+    }
 }
 
 // MARK: Sign in SSO

--- a/PJ3T3_Postie/Manager/AuthManager.swift
+++ b/PJ3T3_Postie/Manager/AuthManager.swift
@@ -202,6 +202,14 @@ extension AuthManager {
         let helper = GoogleSignInHelper()
         let tokens = try await helper.googleHelperSingIn()
         
+        if userSession != nil {
+            if tokens.email != userSession?.email {
+                throw AuthErrorCode(.userMismatch)
+            } else {
+                return GoogleAuthProvider.credential(withIDToken: tokens.idToken, accessToken: tokens.accessToken)
+            }
+        }
+        
         return GoogleAuthProvider.credential(withIDToken: tokens.idToken, accessToken: tokens.accessToken)
     }
     

--- a/PJ3T3_Postie/Manager/AuthManager.swift
+++ b/PJ3T3_Postie/Manager/AuthManager.swift
@@ -17,11 +17,11 @@ class AuthManager: ObservableObject {
     static let shared = AuthManager()
     var userUid: String  = ""
     var hasAccount: Bool = true
-    var authDataResult: AuthDataResult?
     var provider: AuthProviderOption?
     @Published var userSession: FirebaseAuth.User? //Firebase user object
     @Published var currentUser: PostieUser? //User Data Model
     @Published var credential: OAuthCredential?
+    @Published var authDataResult: AuthDataResult?
     
     private init() {
         Task {
@@ -246,8 +246,11 @@ extension AuthManager {
         let credential = OAuthProvider.appleCredential(withIDToken: user.token,
                                                        rawNonce: user.nonce,
                                                        fullName: user.fullName)
+        let authDataResult = try await signInWithSSO(credential: credential)
         
-        self.authDataResult = try await signInWithSSO(credential: credential)
+        DispatchQueue.main.async {
+            self.authDataResult = authDataResult
+        }
     }
     
     func deleteAppleAccount(user: AppleUser, authCodeString: String) async {

--- a/PJ3T3_Postie/Manager/AuthManager.swift
+++ b/PJ3T3_Postie/Manager/AuthManager.swift
@@ -209,7 +209,6 @@ extension AuthManager {
         do {
             let credential = try await signInWithGoogle()
             try await self.userSession?.reauthenticate(with: credential)
-            self.deleteAccount()
         } catch let error as NSError {
             if error.code == GIDSignInErrorCode.canceled.rawValue {
                 throw GIDSignInErrorCode.canceled

--- a/PJ3T3_Postie/Manager/AuthManager.swift
+++ b/PJ3T3_Postie/Manager/AuthManager.swift
@@ -225,13 +225,20 @@ extension AuthManager {
                                                         fullName: user.fullName)
     }
     
-    func deleteAppleAccount(authCodeString: String) async {
+    func reAuthAppleAccount(user: AppleUser) async throws {
+        let credential = OAuthProvider.appleCredential(withIDToken: user.token,
+                                                       rawNonce: user.nonce,
+                                                       fullName: user.fullName)
+        
+        self.authDataResult = try await signInWithSSO(credential: credential)
+    }
+    
+    func deleteAppleAccount(user: AppleUser, authCodeString: String) async {
+        let credential = OAuthProvider.appleCredential(withIDToken: user.token,
+                                                       rawNonce: user.nonce,
+                                                       fullName: user.fullName)
+        
         do {
-            guard let credential = self.credential else {
-                print(#function, "Failed to get credential")
-                return
-            }
-            
             try await self.userSession?.reauthenticate(with: credential)
             try await Auth.auth().revokeToken(withAuthorizationCode: authCodeString)
             self.deleteAccount()


### PR DESCRIPTION
<!-- 작업 동기에는 해당 작업을 수행한 이유 또는 목적을 간단히 적어주세요. -->
<!-- in progress는 진행중인 연관 이슈, close에는 닫고싶은 issue를 적습니다. -->
## 개요
- in progress
- close #142 #153 
- 작업 요약: 닉네임뷰 오류시 유저 플로우 수정 및 탈퇴 또는 재인증시 계정 선택 오류 이슈 핸들링


<!-- PR의 핵심이 되는 작업 내용을 적어주세요. -->
## 변경 사항
- 회원가입 중 닉네임 제출 전 앱이 종료되면 계정 재인증해 회원가입 이어가도록 수정
  - 계정 재인증 완료 후 닉네임 확정 버튼으로 바로 연결
  - 기존은 회원탈퇴 후 재가입했으나, 유저 이탈을 고려해 재인증 후 바로 가입 하도록 수정
- 재인증시 계정 선택 오류 이슈 핸들링
- 계정 재인증 취소시 error handling

<!-- 노션 팀 페이지에 정리한 글의 링크나 참고한 블로그의 링크를 남겨주세요. -->
## 공유사항(배운 것, 참고하면 좋을 것)
- [Reading Firebase Auth Error Thrown (Firebase 3.x and Swift)](https://stackoverflow.com/questions/37449919/reading-firebase-auth-error-thrown-firebase-3-x-and-swift)
- [Authentication in Firebase using Swift Error Handling - Part2 | Swift Tutorials | FIREBASE and XCODE](https://www.youtube.com/watch?v=9zDI7I20wfQ)

<!-- 이미지 가로 크기 216 고정 -->
## 스크린샷
|제목|작업 전|작업 후|작업 후|
|:-:|:-:|:-:|:-:|
|닉네임뷰 재인증||<img width="216" src="https://github.com/APP-iOS3rd/PJ3T3_Postie/assets/106911494/94259bf6-ab30-4a3b-b48a-8d1ceb4ddfb9">|<img width="216" src="https://github.com/APP-iOS3rd/PJ3T3_Postie/assets/106911494/cb664d5c-7ef5-4b90-8bb5-f6e867fc32f2">|
|탈퇴 재인증||<img width="216" src="https://github.com/APP-iOS3rd/PJ3T3_Postie/assets/106911494/6ca5a5ad-c8ef-4b6d-93ec-05d4629dbd1f">|<img width="216" src="https://github.com/APP-iOS3rd/PJ3T3_Postie/assets/106911494/04010c79-3f69-4a0d-bef4-70a0f79c368c">|

<!-- 질문, 중점적으로 확인받고 싶은 내용 또는 주의사항 등 자유로운 전달사항 적어주세요. -->
## 전달사항
-
