### PR TITLE
느린 우체통 뷰 생성 및 알림 기능 연결

### DIFF
--- a/PJ3T3_Postie.xcodeproj/project.pbxproj
+++ b/PJ3T3_Postie.xcodeproj/project.pbxproj
@@ -96,6 +96,8 @@
 		CE67D55E2B58FF8500C0050B /* String.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE67D55D2B58FF8500C0050B /* String.swift */; };
 		CE6E08452B5E09D900CFBF2A /* LetterDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE6E08442B5E09D800CFBF2A /* LetterDetailViewModel.swift */; };
 		CE7E50782B579D6800955F31 /* AddLetterViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE7E50772B579D6800955F31 /* AddLetterViewModel.swift */; };
+		CE8E67092B8715E50090A6EE /* SlowPostBoxView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE8E67082B8715E50090A6EE /* SlowPostBoxView.swift */; };
+		CE8E670B2B87163B0090A6EE /* SlowPostBoxViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE8E670A2B87163B0090A6EE /* SlowPostBoxViewModel.swift */; };
 		CEF09E452B57B6C500BE67E4 /* UIImagePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEF09E442B57B6C500BE67E4 /* UIImagePicker.swift */; };
 		CEF09E472B57BD8500BE67E4 /* LetterImageFullScreenView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEF09E462B57BD8500BE67E4 /* LetterImageFullScreenView.swift */; };
 		CEF09E492B57BFBF00BE67E4 /* TextRecognizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEF09E482B57BFBF00BE67E4 /* TextRecognizer.swift */; };
@@ -195,6 +197,8 @@
 		CE67D55D2B58FF8500C0050B /* String.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = String.swift; sourceTree = "<group>"; };
 		CE6E08442B5E09D800CFBF2A /* LetterDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LetterDetailViewModel.swift; sourceTree = "<group>"; };
 		CE7E50772B579D6800955F31 /* AddLetterViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddLetterViewModel.swift; sourceTree = "<group>"; };
+		CE8E67082B8715E50090A6EE /* SlowPostBoxView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlowPostBoxView.swift; sourceTree = "<group>"; };
+		CE8E670A2B87163B0090A6EE /* SlowPostBoxViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlowPostBoxViewModel.swift; sourceTree = "<group>"; };
 		CEF09E442B57B6C500BE67E4 /* UIImagePicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIImagePicker.swift; sourceTree = "<group>"; };
 		CEF09E462B57BD8500BE67E4 /* LetterImageFullScreenView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LetterImageFullScreenView.swift; sourceTree = "<group>"; };
 		CEF09E482B57BFBF00BE67E4 /* TextRecognizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextRecognizer.swift; sourceTree = "<group>"; };
@@ -398,6 +402,7 @@
 				CE6E08442B5E09D800CFBF2A /* LetterDetailViewModel.swift */,
 				CEF09E482B57BFBF00BE67E4 /* TextRecognizer.swift */,
 				E36587AA2B7E34E400584965 /* GroupedLetterViewModel.swift */,
+				CE8E670A2B87163B0090A6EE /* SlowPostBoxViewModel.swift */,
 				E36587AC2B7E6ED200584965 /* SummaryApi.swift */,
 			);
 			path = ViewModel;
@@ -417,6 +422,7 @@
 				E349F8852B6B672E00253B02 /* ListLetterView.swift */,
 				CE67D55B2B58E9F700C0050B /* PageViewController.swift */,
 				9E5889E22B72221B00B4AD20 /* SearchView.swift */,
+				CE8E67082B8715E50090A6EE /* SlowPostBoxView.swift */,
 				CEF09E442B57B6C500BE67E4 /* UIImagePicker.swift */,
 			);
 			path = View;
@@ -824,6 +830,7 @@
 				0E882AF02B6B79D800D8F2FC /* CoordinaterEtc.swift in Sources */,
 				CE4F1AD22B7CDF8800FE7CF6 /* EditLetterView.swift in Sources */,
 				0E882AEE2B6B73DE00D8F2FC /* LocationManager.swift in Sources */,
+				CE8E670B2B87163B0090A6EE /* SlowPostBoxViewModel.swift in Sources */,
 				E36587A92B7C44EB00584965 /* AlertView.swift in Sources */,
 				9E9F6AD42B576411003DFE83 /* LetterDetailView.swift in Sources */,
 				E3D466DB2B733B5B00DFE93F /* MembershipView.swift in Sources */,
@@ -846,6 +853,7 @@
 				E39C35F12B71F820001F6E5F /* ContenViewModel.swift in Sources */,
 				9E9F6ACA2B5763B8003DFE83 /* LoginView.swift in Sources */,
 				9E7E05BB2B7DE96500ACF177 /* OfficialLetter.swift in Sources */,
+				CE8E67092B8715E50090A6EE /* SlowPostBoxView.swift in Sources */,
 				E349F8882B6B673C00253B02 /* GroupedLetterView.swift in Sources */,
 				9E25C2CD2B7B454000B04BA1 /* EnvironmentValues.swift in Sources */,
 				9E46837C2B7BBBA100EFB90B /* LoadingView.swift in Sources */,

--- a/PJ3T3_Postie/Core/Home/View/HomeView.swift
+++ b/PJ3T3_Postie/Core/Home/View/HomeView.swift
@@ -274,7 +274,7 @@ struct AddLetterButton: View {
     
     var body: some View {
         Menu {
-            NavigationLink(destination: AddLetterView(isReceived: false)) {
+            NavigationLink(destination: SlowPostBoxView(isReceived: false)) {
                 Label("나의 느린 우체통", systemImage: "envelope.open.badge.clock")
             }
             

--- a/PJ3T3_Postie/Core/Home/View/LetterDetailView.swift
+++ b/PJ3T3_Postie/Core/Home/View/LetterDetailView.swift
@@ -25,7 +25,7 @@ struct LetterDetailView: View {
             ThemeManager.themeColors[isThemeGroupButton].backGroundColor
                 .ignoresSafeArea()
             
-            VStack {
+            VStack(spacing: 16) {
                 Page(letter: $firestoreManager.letter)
 
                 letterSummarySection

--- a/PJ3T3_Postie/Core/Home/View/SlowPostBoxView.swift
+++ b/PJ3T3_Postie/Core/Home/View/SlowPostBoxView.swift
@@ -166,7 +166,7 @@ extension SlowPostBoxView {
             .frame(maxWidth: .infinity)
 
             VStack(alignment: .leading, spacing: 4) {
-                Text(isReceived ? "받은 날짜" : "보낸 날짜")
+                Text("받을 날짜")
 
                 DatePicker(
                     "",

--- a/PJ3T3_Postie/Core/Home/View/SlowPostBoxView.swift
+++ b/PJ3T3_Postie/Core/Home/View/SlowPostBoxView.swift
@@ -58,7 +58,7 @@ struct SlowPostBoxView: View {
         .toolbarBackground(ThemeManager.themeColors[isThemeGroupButton].backGroundColor, for: .navigationBar)
         .toolbar {
             ToolbarItemGroup(placement: .principal) {
-                Text(isReceived ? "받은 편지 기록" : "보낸 편지 기록")
+                Text("느린우체통")
                     .bold()
                     .foregroundStyle(ThemeManager.themeColors[isThemeGroupButton].tintColor)
             }

--- a/PJ3T3_Postie/Core/Home/View/SlowPostBoxView.swift
+++ b/PJ3T3_Postie/Core/Home/View/SlowPostBoxView.swift
@@ -1,0 +1,330 @@
+//
+//  SlowPostBoxView.swift
+//  PJ3T3_Postie
+//
+//  Created by KHJ on 2024/02/22.
+//
+
+import SwiftUI
+
+struct SlowPostBoxView: View {
+    @StateObject private var slowPostBoxViewModel: SlowPostBoxViewModel
+    @ObservedObject var firestoreManager = FirestoreManager.shared
+    @ObservedObject var storageManager = StorageManager.shared
+
+    enum Field: Hashable {
+        case sender
+        case receiver
+        case text
+        case summary
+    }
+
+    var isReceived: Bool
+
+    @FocusState private var focusField: Field?
+    @Environment(\.dismiss) var dismiss
+    @AppStorage("isThemeGroupButton") private var isThemeGroupButton: Int = 0
+
+    init(isReceived: Bool) {
+        self.isReceived = isReceived
+        self._slowPostBoxViewModel = StateObject(wrappedValue: SlowPostBoxViewModel(isReceived: isReceived))
+
+        // TextEditor 패딩
+        UITextView.appearance().textContainerInset = UIEdgeInsets(
+            top: 12,
+            left: 8,
+            bottom: 12,
+            right: 8
+        )
+    }
+
+    var body: some View {
+        ZStack {
+            ThemeManager.themeColors[isThemeGroupButton].backGroundColor
+                .ignoresSafeArea()
+
+            ScrollView {
+                VStack(alignment: .leading, spacing: 16) {
+                    letterInfoSection
+
+                    letterImagesSection
+
+                    letterTextSection
+                }
+                .padding()
+            }
+        }
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbarBackground(ThemeManager.themeColors[isThemeGroupButton].backGroundColor, for: .navigationBar)
+        .toolbar {
+            ToolbarItemGroup(placement: .principal) {
+                Text(isReceived ? "받은 편지 기록" : "보낸 편지 기록")
+                    .bold()
+                    .foregroundStyle(ThemeManager.themeColors[isThemeGroupButton].tintColor)
+            }
+
+            ToolbarItemGroup(placement: .topBarTrailing) {
+                Button {
+                    Task {
+                        await slowPostBoxViewModel.uploadLetter()
+                    }
+                } label : {
+                    Text("완료")
+                }
+                .disabled(slowPostBoxViewModel.isLoading)
+            }
+
+            ToolbarItemGroup(placement: .keyboard) {
+                Spacer()
+
+                Button {
+                    focusField = nil
+                } label: {
+                    Image(systemName: "keyboard.chevron.compact.down")
+                }
+            }
+        }
+        .toolbar(.hidden, for: .tabBar)
+        .scrollDismissesKeyboard(.interactively)
+        .modifier(LoadingModifier(isLoading: $slowPostBoxViewModel.isLoading, text: slowPostBoxViewModel.loadingText))
+        .fullScreenCover(isPresented: $slowPostBoxViewModel.showingLetterImageFullScreenView) {
+            LetterImageFullScreenView(
+                images: slowPostBoxViewModel.images,
+                pageIndex: $slowPostBoxViewModel.selectedIndex
+            )
+        }
+        .sheet(isPresented: $slowPostBoxViewModel.showingUIImagePicker) {
+            UIImagePicker(
+                sourceType: slowPostBoxViewModel.imagePickerSourceType,
+                selectedImages: $slowPostBoxViewModel.images,
+                text: $slowPostBoxViewModel.text,
+                isLoading: $slowPostBoxViewModel.isLoading,
+                showingTextRecognizerErrorAlert: $slowPostBoxViewModel.showingTextRecognizerErrorAlert,
+                loadingText: $slowPostBoxViewModel.loadingText
+            )
+            .ignoresSafeArea(.all, edges: .bottom)
+        }
+        .alert("문자 인식 실패", isPresented: $slowPostBoxViewModel.showingTextRecognizerErrorAlert) {
+
+        } message: {
+            Text("문자 인식에 실패했습니다. 다시 시도해 주세요.")
+        }
+        .alert("한 줄 요약", isPresented: $slowPostBoxViewModel.showingSummaryAlert) {
+            Button("직접 작성") {
+                slowPostBoxViewModel.showSummaryTextField()
+                focusField = .summary
+            }
+
+            Button("AI 완성") {
+                Task {
+                    await slowPostBoxViewModel.getSummary()
+                }
+                focusField = .summary
+            }
+        }
+        .alert("편지 정보 부족", isPresented: $slowPostBoxViewModel.showingNotEnoughInfoAlert) {
+
+        } message: {
+            Text("편지를 저장하기 위한 정보가 부족해요. \(isReceived ? "보낸 사람" : "받는 사람")과 내용을 채워주세요.")
+        }
+        .alert("편지 저장 실패", isPresented: $slowPostBoxViewModel.showingUploadErrorAlert) {
+
+        } message: {
+            Text("편지 저장에 실패했어요. 다시 시도해주세요.")
+        }
+        .alert("편지 요약 실패", isPresented: $slowPostBoxViewModel.showingSummaryErrorAlert) {
+
+        } message: {
+            Text("편지 요약에 실패했어요. 직접 요약해주세요.")
+        }
+        .customOnChange(slowPostBoxViewModel.shouldDismiss) { shouldDismiss in
+            if shouldDismiss {
+                dismiss()
+            }
+        }
+    }
+}
+
+// MARK: - Computed Views
+
+extension SlowPostBoxView {
+    @ViewBuilder
+    private var letterInfoSection: some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(isReceived ? "보낸 사람" : "받는 사람")
+
+                TextField("",
+                          text: .constant(slowPostBoxViewModel.currentUserName)
+                )
+                .padding(6)
+                .background(ThemeManager.themeColors[isThemeGroupButton].receivedLetterColor)
+                .clipShape(RoundedRectangle(cornerRadius: 4))
+                .focused($focusField, equals: .sender)
+                .disabled(true)
+            }
+            .frame(maxWidth: .infinity)
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(isReceived ? "받은 날짜" : "보낸 날짜")
+
+                DatePicker(
+                    "",
+                    selection: $slowPostBoxViewModel.date,
+                    in: Calendar.current.date(byAdding: .day, value: 1, to: Date())!...,
+                    displayedComponents: .date
+                )
+                .labelsHidden()
+                .environment(\.locale, Locale.init(identifier: "ko"))
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var letterImagesSection: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Text("편지 사진")
+
+                Spacer()
+
+                Menu {
+                    Button {
+                        slowPostBoxViewModel.showUIImagePicker(sourceType: .photoLibrary)
+                    } label: {
+                        HStack {
+                            Text("사진 보관함")
+
+                            Spacer()
+
+                            Image(systemName: "photo.on.rectangle")
+                        }
+                    }
+
+                    Button {
+                        slowPostBoxViewModel.showUIImagePicker(sourceType: .camera)
+                    } label: {
+                        HStack {
+                            Text("사진 찍기")
+
+                            Spacer()
+
+                            Image(systemName: "camera")
+                        }
+                    }
+                } label: {
+                    Image(systemName: "plus")
+                }
+            }
+
+            if slowPostBoxViewModel.images.isEmpty {
+                Label("사진을 추가해주세요.", systemImage: "photo.on.rectangle")
+                    .foregroundStyle(ThemeManager.themeColors[isThemeGroupButton].dividerColor)
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 100)
+                    .frame(alignment: .center)
+            } else {
+                ScrollView(.horizontal) {
+                    HStack(spacing: 8) {
+                        ForEach(0..<slowPostBoxViewModel.images.count, id: \.self) { index in
+                            ZStack(alignment: .topTrailing) {
+                                Button {
+                                    slowPostBoxViewModel.showLetterImageFullScreenView(index: index)
+                                } label: {
+                                    Image(uiImage: slowPostBoxViewModel.images[index])
+                                        .resizable()
+                                        .scaledToFill()
+                                        .frame(width: 100, height: 100)
+                                        .clipShape(RoundedRectangle(cornerRadius: 4))
+                                }
+
+                                Button {
+                                    withAnimation {
+                                        slowPostBoxViewModel.removeImage(at: index)
+                                    }
+                                } label: {
+                                    Image(systemName: "xmark.circle.fill")
+                                        .symbolRenderingMode(.palette)
+                                        .foregroundStyle(.white, ThemeManager.themeColors[isThemeGroupButton].tintColor)
+                                }
+                                .offset(x: 8, y: -8)
+                            }
+                        }
+                    }
+                    .padding(.top, 8)
+                    .padding(.trailing, 8)
+                }
+                .scrollIndicators(.never)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var letterTextSection: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text("내용")
+
+            ZStack {
+                if slowPostBoxViewModel.text.isEmpty {
+                    TextEditor(text: .constant("사진을 등록하면 자동으로 편지 내용이 입력됩니다."))
+                        .scrollContentBackground(.hidden)
+                        .background(ThemeManager.themeColors[isThemeGroupButton].receivedLetterColor)
+                        .lineSpacing(5)
+                        .clipShape(RoundedRectangle(cornerRadius: 4))
+                        .frame(maxWidth: .infinity)
+                        .frame(height: 350)
+                        .disabled(true)
+                }
+
+                TextEditor(text: $slowPostBoxViewModel.text)
+                    .scrollContentBackground(.hidden)
+                    .background(ThemeManager.themeColors[isThemeGroupButton].receivedLetterColor)
+                    .lineSpacing(5)
+                    .clipShape(RoundedRectangle(cornerRadius: 4))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 4)
+                            .stroke(.black, lineWidth: 1 / 4)
+                            .opacity(0.2)
+                    )
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 350)
+                    .opacity(slowPostBoxViewModel.text.isEmpty ? 0.25 : 1)
+                    .focused($focusField, equals: .text)
+            }
+        }
+
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Text("한 줄 요약")
+
+                Spacer()
+
+                Button {
+                    slowPostBoxViewModel.showSummaryAlert()
+                } label: {
+                    Image(systemName: "plus")
+                }
+            }
+
+            if slowPostBoxViewModel.showingSummaryTextField || !slowPostBoxViewModel.summary.isEmpty {
+                TextField("", text: $slowPostBoxViewModel.summary)
+                    .padding(6)
+                    .background(ThemeManager.themeColors[isThemeGroupButton].receivedLetterColor)
+                    .clipShape(RoundedRectangle(cornerRadius: 4))
+                    .focused($focusField, equals: .summary)
+            } else {
+                Label("편지를 요약해드릴게요.", systemImage: "text.quote.rtl")
+                    .foregroundStyle(ThemeManager.themeColors[isThemeGroupButton].dividerColor)
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 30)
+                    .frame(alignment: .center)
+
+            }
+        }
+    }
+}
+
+
+#Preview {
+    SlowPostBoxView(isReceived: false)
+}

--- a/PJ3T3_Postie/Core/Home/ViewModel/SlowPostBoxViewModel.swift
+++ b/PJ3T3_Postie/Core/Home/ViewModel/SlowPostBoxViewModel.swift
@@ -1,0 +1,172 @@
+//
+//  SlowPostBoxViewModel.swift
+//  PJ3T3_Postie
+//
+//  Created by KHJ on 2024/02/22.
+//
+
+import Foundation
+import UIKit
+
+class SlowPostBoxViewModel: ObservableObject {
+    @Published var sender: String = ""
+    @Published var receiver: String = ""
+    @Published var date: Date = .now
+    @Published var text: String = ""
+    @Published var summary: String = ""
+    @Published var images: [UIImage] = []
+    @Published var selectedIndex: Int = 0
+    @Published var showingUIImagePicker = false
+    @Published var showingLetterImageFullScreenView: Bool = false
+    @Published var showingTextRecognizerErrorAlert: Bool = false
+    @Published var showingSummaryTextField: Bool = false
+    @Published var showingSummaryAlert: Bool = false
+    @Published var showingNotEnoughInfoAlert: Bool = false
+    @Published var showingUploadErrorAlert: Bool = false
+    @Published var showingSummaryErrorAlert: Bool = false
+    @Published var shouldDismiss: Bool = false
+    @Published var isLoading: Bool = false
+    @Published var loadingText: String = "편지를 저장하고 있어요."
+
+    private(set) var imagePickerSourceType: UIImagePickerController.SourceType = .camera
+    var isReceived: Bool
+    var isNotEnoughInfo: Bool {
+        (isReceived && (sender.isEmpty || text.isEmpty))
+            || (!isReceived && (receiver.isEmpty || text.isEmpty))
+    }
+    var currentUserName: String {
+        AuthManager.shared.currentUser?.nickname ??
+                        AuthManager.shared.currentUser?.fullName ??
+                        AuthManager.shared.currentUser?.id ??
+                        "유저"
+    }
+
+    init(isReceived: Bool) {
+        self.isReceived = isReceived
+    }
+
+    private func dismissView() {
+        shouldDismiss = true
+    }
+
+    func removeImage(at index: Int) {
+        images.remove(at: index)
+    }
+
+    func showUIImagePicker(sourceType: UIImagePickerController.SourceType) {
+        imagePickerSourceType = sourceType
+        showingUIImagePicker = true
+    }
+
+    func showNotEnoughInfoAlert() {
+        showingNotEnoughInfoAlert = true
+    }
+
+    func showLetterImageFullScreenView(index: Int) {
+        selectedIndex = index
+        showingLetterImageFullScreenView = true
+    }
+
+    func showSummaryTextField() {
+        showingSummaryTextField = true
+    }
+
+    func showSummaryAlert() {
+        showingSummaryAlert = true
+    }
+
+    func showSummaryErrorAlert() {
+        showingSummaryErrorAlert = true
+    }
+
+    func showUploadErrorAlert() {
+        showingUploadErrorAlert = true
+    }
+
+    func uploadLetter() async {
+        if isNotEnoughInfo {
+            await MainActor.run {
+                showNotEnoughInfoAlert()
+            }
+        } else {
+            await MainActor.run {
+                isLoading = true
+                loadingText = "편지를 저장하고 있어요."
+            }
+
+            do {
+                let docId = UUID().uuidString
+
+                let (newImageFullPaths, newImageUrls) = try await uploadImages(docId: docId)
+                try await addLetter(docId: docId, newImageUrls: newImageUrls, newImageFullPaths: newImageFullPaths, isReceived: isReceived)
+
+                await MainActor.run {
+                    dismissView()
+                }
+            } catch {
+                await MainActor.run {
+                    isLoading = false
+
+                    showUploadErrorAlert()
+                }
+            }
+        }
+    }
+
+    func uploadImages(docId: String) async throws -> ([String], [String]) {
+        var newImageFullPaths = [String]()
+        var newImageUrls = [String]()
+
+        // 이미지 추가
+        for image in images {
+            let fullPath = try await StorageManager.shared.uploadUIImage(image: image, docId: docId)
+            let url = try await StorageManager.shared.requestImageURL(fullPath: fullPath)
+            newImageFullPaths.append(fullPath)
+            newImageUrls.append(url)
+        }
+
+        return (newImageFullPaths, newImageUrls)
+    }
+
+    func addLetter(docId: String, newImageUrls: [String], newImageFullPaths: [String], isReceived: Bool) async throws {
+        let writer = currentUserName
+        let recipient = currentUserName
+
+        let newLetter = Letter(
+            id: docId,
+            writer: writer,
+            recipient: recipient,
+            summary: summary,
+            date: date,
+            text: text,
+            isReceived: isReceived,
+            isFavorite: false,
+            imageURLs: newImageUrls,
+            imageFullPaths: newImageFullPaths
+        )
+
+        try await FirestoreManager.shared.addLetter(docId: docId, letter: newLetter)
+
+        await MainActor.run {
+            FirestoreManager.shared.letters.append(newLetter)
+        }
+    }
+
+    func getSummary() async {
+        do {
+            let summaryResponse = try await APIClient.shared.postRequestToAPI(
+                title: isReceived ? "\(sender)에게 받은 편지" : "\(receiver)에게 쓴 편지",
+                content: text
+            )
+
+            await MainActor.run {
+                summary = summaryResponse
+                showSummaryTextField()
+            }
+        } catch {
+            await MainActor.run {
+                showSummaryErrorAlert()
+            }
+        }
+    }
+}

--- a/PJ3T3_Postie/Core/Home/ViewModel/SlowPostBoxViewModel.swift
+++ b/PJ3T3_Postie/Core/Home/ViewModel/SlowPostBoxViewModel.swift
@@ -31,8 +31,7 @@ class SlowPostBoxViewModel: ObservableObject {
     private(set) var imagePickerSourceType: UIImagePickerController.SourceType = .camera
     var isReceived: Bool
     var isNotEnoughInfo: Bool {
-        (isReceived && (sender.isEmpty || text.isEmpty))
-            || (!isReceived && (receiver.isEmpty || text.isEmpty))
+        text.isEmpty
     }
     var currentUserName: String {
         AuthManager.shared.currentUser?.nickname ??
@@ -98,7 +97,10 @@ class SlowPostBoxViewModel: ObservableObject {
                 let docId = UUID().uuidString
 
                 let (newImageFullPaths, newImageUrls) = try await uploadImages(docId: docId)
+
                 try await addLetter(docId: docId, newImageUrls: newImageUrls, newImageFullPaths: newImageFullPaths, isReceived: isReceived)
+
+                setNotification(docId: docId, date: date)
 
                 await MainActor.run {
                     dismissView()
@@ -168,5 +170,12 @@ class SlowPostBoxViewModel: ObservableObject {
                 showSummaryErrorAlert()
             }
         }
+    }
+
+    func setNotification(docId: String, date: Date) {
+        let manager = NotificationManager.shared
+        //title이나 body 부분의 문구 여러가지로 배열 작성 해 두었다가 알람 뜰 때 랜덤으로 설정되면 좋을 것 같아요~
+        manager.addNotification(id: docId, title: "포스티가 편지를 배달했어요", body: summary.count == 0 ? "포스티에서 내용을 확인 해 보세요" : summary)
+        manager.setNotification(date: date)
     }
 }


### PR DESCRIPTION
<!-- 작업 동기에는 해당 작업을 수행한 이유 또는 목적을 간단히 적어주세요. -->
<!-- in progress는 진행중인 연관 이슈, close에는 닫고싶은 issue를 적습니다. -->
## 개요
- close  #162 #163

<!-- PR의 핵심이 되는 작업 내용을 적어주세요. -->
## 변경 사항
- 느린 우체통 뷰 생성
- 알림 기능 연결

<!-- 이미지 가로 크기 216 고정 -->
## 스크린샷
|제목|작업 전|작업 후|
|:-:|:-:|:-:| 
|||<img src="https://github.com/APP-iOS3rd/PJ3T3_Postie/assets/119300554/32f9bb45-fbb2-49bf-a6e6-b4af89d797c5" width="216">
|

<!-- 질문, 중점적으로 확인받고 싶은 내용 또는 주의사항 등 자유로운 전달사항 적어주세요. -->
## 전달사항
- 받는 사람을 원래 삭제했는 데 본인의 닉네임으로 설정하는 게 더 좋을 것 같아서 뷰에 남겨뒀습니다.
- 날짜는 내일부터 받을 수 있도록 설정했습니다. 
- 보낸이와 받는이에 들어갈 이름은 닉네임 - 풀네임 - 아이디 - 기본 값으로 설정했습니다.
```swift
    var currentUserName: String {
        AuthManager.shared.currentUser?.nickname ??
                        AuthManager.shared.currentUser?.fullName ??
                        AuthManager.shared.currentUser?.id ??
                        "유저"
    }
```