### PR TITLE
알림뷰 버그 수정

### DIFF
--- a/PJ3T3_Postie/Core/Setting/View/AlertView.swift
+++ b/PJ3T3_Postie/Core/Setting/View/AlertView.swift
@@ -11,7 +11,7 @@ import UserNotifications
 struct AlertView: View {
     @AppStorage("isThemeGroupButton") private var isThemeGroupButton: Int = 0
     @AppStorage("allAlert") private var allAlert: Bool = true
-    @State private var slowAlert = true
+    @AppStorage("slowAlert") private var slowAlert: Bool = true
     
     func moveToNotificationSetting() {
         if let url = URL(string: UIApplication.openNotificationSettingsURLString) {

--- a/PJ3T3_Postie/Core/Setting/View/AlertView.swift
+++ b/PJ3T3_Postie/Core/Setting/View/AlertView.swift
@@ -10,8 +10,8 @@ import UserNotifications
 
 struct AlertView: View {
     @AppStorage("isThemeGroupButton") private var isThemeGroupButton: Int = 0
-    @AppStorage("allAlert") private var allAlert: Bool = true
-    @AppStorage("slowAlert") private var slowAlert: Bool = true
+    @AppStorage("allAlert") private var allAlert: Bool = false
+    @AppStorage("slowAlert") private var slowAlert: Bool = false
     
     func moveToNotificationSetting() {
         if let url = URL(string: UIApplication.openNotificationSettingsURLString) {


### PR DESCRIPTION
## 개요
- in progress
- close 
- 작업 요약
- 전체알림 초기값이 true인데, 느린우체통 보내기전까지 알림이 의미없음 (설정 경로도 못찾음), 그래서 초기값 false로 변경
- 느린알림 state로 해두니 들어갈때마다 초기값인 true로 변경되는 버그 수정

## 변경 사항
- 전체 알림 초기값 false로 변경
- 느린 알림 Appstorage로 변경

## 공유사항(배운 것, 참고하면 좋을 것)
- 

## 스크린샷

## 전달사항
-

