### PR TITLE
앱스토어 업데이트 알림창 설정 변경

### DIFF
--- a/PJ3T3_Postie/Extenstions/String.swift
+++ b/PJ3T3_Postie/Extenstions/String.swift
@@ -14,8 +14,7 @@ extension String {
     func chunks(size: Int) -> [String] {
         return stride(from: 0, to: count, by: size).map { index in
             let startIndex = self.index(self.startIndex, offsetBy: index)
-            let endIndex = self.index(startIndex, offsetBy: size,
-                                      limitedBy: self.endIndex) ?? self.endIndex
+            let endIndex = self.index(startIndex, offsetBy: size, limitedBy: self.endIndex) ?? self.endIndex
             return String(self[startIndex..<endIndex])
         }
     }

--- a/PJ3T3_Postie/Manager/AppStoreUpdateChecker.swift
+++ b/PJ3T3_Postie/Manager/AppStoreUpdateChecker.swift
@@ -11,21 +11,21 @@ import OSLog
 struct AppStoreUpdateChecker {
     static func isNewVersionAvailable() async -> Bool {
 //        let bundleID = "com.iloen.iphonemelon" //코드 테스트시 12행 활성화, 14행은 주석처리
-        guard
-            let bundleID = Bundle.main.bundleIdentifier,
-            let countryCode = Locale.current.language.region?.identifier,
-            let currentVersionNumber = Bundle.main.releaseVersionNumber,
-            let url = URL(string: "https://itunes.apple.com/lookup?bundleId=\(bundleID)&country=\(countryCode)")
-        else {
-            Logger.version.error("bunldeID 또는 countryCode 찾지 못함")
-            return false
-        }
-        Logger.version.info("---> url: \(url)")
+//        guard
+//            let bundleID = Bundle.main.bundleIdentifier,
+//            let countryCode = Locale.current.language.region?.identifier,
+//            let url = URL(string: "https://itunes.apple.com/lookup?bundleId=\(bundleID)&country=\(countryCode)"),
+//            let currentVersionNumber = Bundle.main.releaseVersionNumber
+//        else {
+//            Logger.version.error("bunldeID 또는 countryCode 찾지 못함")
+//            return false
+//        }
 
         do {
-            let appleID = 6478052812
+            let appleID = 6478052812 //415597317
             
-            guard let url = URL(string: "https://itunes.apple.com/lookup?id=\(appleID)&country=kr"),
+            guard let currentVersionNumber = Bundle.main.releaseVersionNumber,
+                  let url = URL(string: "https://itunes.apple.com/lookup?id=\(appleID)&country=kr"),
                   let data = try? Data(contentsOf: url),
                   let json = try JSONSerialization.jsonObject(with: data, options: .allowFragments) as? [String: Any],
                   let results = json["results"] as? [[String: Any]],
@@ -34,8 +34,10 @@ struct AppStoreUpdateChecker {
                 return false
             }
             
+            Logger.version.info("---> url: \(url)")
+            
             /*버전 1.1.0부터는 셋쩨자리를 비교해서 업데이트 하도록 하면 좋을 것 같아 작성한 코드입니다.
-             지금은 모든 패치가 중요할 수 있어 우선 모든 업데이트마다 알림을 뜨게 하였습니다.
+             지금은 모든 패치가 중요할 수 있어 우선 모든 업데이트마다 알림을 뜨게 하였습니다. */
             let splitLatestVersion = appStoreVersionNumber.split(separator: ".").map { $0 }
             let splitCurrentVersion = currentVersionNumber.split(separator: ".").map { $0 }
             
@@ -47,18 +49,17 @@ struct AppStoreUpdateChecker {
                 print("----> 최신 버전 둘째자리:", splitLatestVersion[1])
                 print("----> 현재 버전 둘째자리:", splitCurrentVersion[1])
                 return true
+            } else if splitLatestVersion[2] > splitCurrentVersion[2] {
+                print("----> 최신 버전 셋째자리:", splitLatestVersion[2])
+                print("----> 현재 버전 셋째자리:", splitCurrentVersion[2])
+                return true
             }
-            
-            print("----> 최신 버전:", splitLatestVersion)
-            print("----> 현재 버전:", splitCurrentVersion)
-            // Checks if there's a mismatch in version numbers
-            return false
-             */
             
             Logger.version.info("----> 최신 버전: \(appStoreVersionNumber)")
             Logger.version.info("----> 현재 버전: \(currentVersionNumber)")
+            
             // Checks if there's a mismatch in version numbers
-            return currentVersionNumber != appStoreVersionNumber
+            return false
         } catch {
             Logger.version.error("버전 찾지 못함: \(error)")
             return false

--- a/PJ3T3_Postie/Manager/AppStoreUpdateChecker.swift
+++ b/PJ3T3_Postie/Manager/AppStoreUpdateChecker.swift
@@ -10,19 +10,8 @@ import OSLog
 
 struct AppStoreUpdateChecker {
     static func isNewVersionAvailable() async -> Bool {
-//        let bundleID = "com.iloen.iphonemelon" //코드 테스트시 12행 활성화, 14행은 주석처리
-//        guard
-//            let bundleID = Bundle.main.bundleIdentifier,
-//            let countryCode = Locale.current.language.region?.identifier,
-//            let url = URL(string: "https://itunes.apple.com/lookup?bundleId=\(bundleID)&country=\(countryCode)"),
-//            let currentVersionNumber = Bundle.main.releaseVersionNumber
-//        else {
-//            Logger.version.error("bunldeID 또는 countryCode 찾지 못함")
-//            return false
-//        }
-
         do {
-            let appleID = 6478052812 //415597317
+            let appleID = 6478052812 //테스트용 다른 앱 아이디: 415597317
             
             guard let currentVersionNumber = Bundle.main.releaseVersionNumber,
                   let url = URL(string: "https://itunes.apple.com/lookup?id=\(appleID)&country=kr"),
@@ -34,10 +23,9 @@ struct AppStoreUpdateChecker {
                 return false
             }
             
-            Logger.version.info("---> url: \(url)")
+            Logger.version.info("----> 최신 버전: \(appStoreVersionNumber)")
+            Logger.version.info("----> 현재 버전: \(currentVersionNumber)")
             
-            /*버전 1.1.0부터는 셋쩨자리를 비교해서 업데이트 하도록 하면 좋을 것 같아 작성한 코드입니다.
-             지금은 모든 패치가 중요할 수 있어 우선 모든 업데이트마다 알림을 뜨게 하였습니다. */
             let splitLatestVersion = appStoreVersionNumber.split(separator: ".").map { $0 }
             let splitCurrentVersion = currentVersionNumber.split(separator: ".").map { $0 }
             

--- a/PJ3T3_Postie/Manager/AppStoreUpdateChecker.swift
+++ b/PJ3T3_Postie/Manager/AppStoreUpdateChecker.swift
@@ -41,25 +41,36 @@ struct AppStoreUpdateChecker {
             let splitLatestVersion = appStoreVersionNumber.split(separator: ".").map { $0 }
             let splitCurrentVersion = currentVersionNumber.split(separator: ".").map { $0 }
             
-            if splitLatestVersion[0] > splitCurrentVersion[0] {
+            //최신버전 첫째자리와 현재 버전 첫째자리 비교
+            if splitLatestVersion[0] == splitCurrentVersion[0] {
+                //최신버전 둘째자리와 현재 버전 둘째자리 비교
+                if splitLatestVersion[1] == splitCurrentVersion[1] {
+                    //최신버전 셋째자리와 현재 버전 셋째자리 비교
+                    if splitLatestVersion[2] <= splitCurrentVersion[2] {
+                        return false
+                    } else {
+                        Logger.version.info("----> 최신 버전 셋째자리: \(splitLatestVersion[2])")
+                        Logger.version.info("----> 현재 버전 셋째자리: \(splitCurrentVersion[2])")
+                        return true
+                    }
+                }
+                
+                if splitLatestVersion[1] < splitCurrentVersion[1] {
+                    return false
+                } else {
+                    Logger.version.info("----> 최신 버전 둘째자리: \(splitLatestVersion[1])")
+                    Logger.version.info("----> 현재 버전 둘째자리: \(splitCurrentVersion[1])")
+                    return true
+                }
+            }
+            
+            if splitLatestVersion[0] < splitCurrentVersion[0] {
+                return false
+            } else {
                 Logger.version.info("----> 최신 버전 첫째자리: \(splitLatestVersion[0])")
                 Logger.version.info("----> 현재 버전 첫째자리: \(splitCurrentVersion[0])")
                 return true
-            } else if splitLatestVersion[1] > splitCurrentVersion[1] {
-                Logger.version.info("----> 최신 버전 둘째자리: \(splitLatestVersion[1])")
-                Logger.version.info("----> 현재 버전 둘째자리: \(splitCurrentVersion[1])")
-                return true
-            } else if splitLatestVersion[2] > splitCurrentVersion[2] {
-                Logger.version.info("----> 최신 버전 셋째자리: \(splitLatestVersion[2])")
-                Logger.version.info("----> 현재 버전 셋째자리: \(splitCurrentVersion[2])")
-                return true
             }
-            
-            Logger.version.info("----> 최신 버전: \(appStoreVersionNumber)")
-            Logger.version.info("----> 현재 버전: \(currentVersionNumber)")
-            
-            // Checks if there's a mismatch in version numbers
-            return false
         } catch {
             Logger.version.error("버전 찾지 못함: \(error)")
             return false

--- a/PJ3T3_Postie/Manager/AppStoreUpdateChecker.swift
+++ b/PJ3T3_Postie/Manager/AppStoreUpdateChecker.swift
@@ -42,16 +42,16 @@ struct AppStoreUpdateChecker {
             let splitCurrentVersion = currentVersionNumber.split(separator: ".").map { $0 }
             
             if splitLatestVersion[0] > splitCurrentVersion[0] {
-                print("----> 최신 버전 첫째자리:", splitLatestVersion[0])
-                print("----> 현재 버전 첫째자리:", splitCurrentVersion[0])
+                Logger.version.info("----> 최신 버전 첫째자리: \(splitLatestVersion[0])")
+                Logger.version.info("----> 현재 버전 첫째자리: \(splitCurrentVersion[0])")
                 return true
             } else if splitLatestVersion[1] > splitCurrentVersion[1] {
-                print("----> 최신 버전 둘째자리:", splitLatestVersion[1])
-                print("----> 현재 버전 둘째자리:", splitCurrentVersion[1])
+                Logger.version.info("----> 최신 버전 둘째자리: \(splitLatestVersion[1])")
+                Logger.version.info("----> 현재 버전 둘째자리: \(splitCurrentVersion[1])")
                 return true
             } else if splitLatestVersion[2] > splitCurrentVersion[2] {
-                print("----> 최신 버전 셋째자리:", splitLatestVersion[2])
-                print("----> 현재 버전 셋째자리:", splitCurrentVersion[2])
+                Logger.version.info("----> 최신 버전 셋째자리: \(splitLatestVersion[2])")
+                Logger.version.info("----> 현재 버전 셋째자리: \(splitCurrentVersion[2])")
                 return true
             }
             

--- a/PJ3T3_Postie/Manager/AuthManager.swift
+++ b/PJ3T3_Postie/Manager/AuthManager.swift
@@ -95,11 +95,7 @@ class AuthManager: ObservableObject {
 
             //hasAccount의 default는 ture로 로그인 과정에서 account가 있는지 확인하는 동안 ProgressView를 보여준다.
             //이 과정이 없을 경우 로그인 계정이 있음에도 NicknameView가 잠시 나타났다가 홈 뷰로 넘어가는 문제가 발생한다.
-            if self.currentUser != nil {
-                self.hasAccount = true
-            } else {
-                self.hasAccount = false
-            }
+            self.hasAccount = self.currentUser != nil
         }
         
         self.getProviders()

--- a/PJ3T3_Postie/Manager/AuthManager.swift
+++ b/PJ3T3_Postie/Manager/AuthManager.swift
@@ -100,13 +100,6 @@ class AuthManager: ObservableObject {
             } else {
                 self.hasAccount = false
             }
-            
-            //NicknameView에서 아무 이름도 입력하지 않은 경우를 판별한다. 필요 없을 경우 삭제할 예정
-            if self.currentUser?.nickname != "" {
-                Logger.auth.info("\(self.currentUser?.nickname ?? "")")
-            } else {
-                Logger.auth.info("This user is logged in without nickname")
-            }
         }
         
         self.getProviders()

--- a/PJ3T3_Postie/Model/Letter.swift
+++ b/PJ3T3_Postie/Model/Letter.swift
@@ -8,8 +8,6 @@
 import Foundation
 import UIKit
 
-import FirebaseFirestore
-
 struct Letter: Codable, Hashable, Identifiable {
     var id: String
     var writer: String

--- a/PJ3T3_Postie/Model/PostieUser.swift
+++ b/PJ3T3_Postie/Model/PostieUser.swift
@@ -5,7 +5,7 @@
 //  Created by Eunsu JEONG on 2/1/24.
 //
 
-import FirebaseAuth
+import Foundation
 
 struct PostieUser: Identifiable, Codable {
     let id: String


### PR DESCRIPTION
<!-- 작업 동기에는 해당 작업을 수행한 이유 또는 목적을 간단히 적어주세요. -->
<!-- in progress는 진행중인 연관 이슈, close에는 닫고싶은 issue를 적습니다. -->
## 개요
- in progress
- close #198 
- 작업 요약: 앱스토어 업데이트 알림창 설정 변경

<!-- PR의 핵심이 되는 작업 내용을 적어주세요. -->
## 변경 사항
- 기존: 앱스토어와 현재 설치 버전이 불일치하면 업데이트 알림
- 수정: 앱스토어 버전보다 현재 설치 버전이 더 작으면 업데이트 알림

<!-- 노션 팀 페이지에 정리한 글의 링크나 참고한 블로그의 링크를 남겨주세요. -->
## 공유사항(배운 것, 참고하면 좋을 것)
- [[iOS] Swift 강제 업데이트 Alert 설정](https://velog.io/@chaentopia/iOS-Swift-%EA%B0%95%EC%A0%9C-%EC%97%85%EB%8D%B0%EC%9D%B4%ED%8A%B8-Alert-%EC%84%A4%EC%A0%95)

<!-- 이미지 가로 크기 216 고정 -->
## 스크린샷
|제목|작업 전|작업 후|
|:-:|:-:|:-:| 
||||

<!-- 질문, 중점적으로 확인받고 싶은 내용 또는 주의사항 등 자유로운 전달사항 적어주세요. -->
## 전달사항
-
